### PR TITLE
DCOS gob support with linkerd/namerd packages

### DIFF
--- a/dcos/DCOS.md
+++ b/dcos/DCOS.md
@@ -1,0 +1,128 @@
+# Gob's Web Service on DC/OS
+
+This documents the steps required to build and deploy Gob on DC/OS, integrated with the linkerd DC/OS package.
+
+All commands are run from the root of this repo.
+
+## Build Images
+
+```bash
+docker build -t buoyantio/gobs-project:gensvc -f gob/Dockerfile-gensvc .
+docker build -t buoyantio/gobs-project:websvc -f gob/Dockerfile-websvc .
+docker build -t buoyantio/gobs-project:wordsvc -f gob/Dockerfile-wordsvc .
+```
+
+## Push Images
+
+```bash
+docker push buoyantio/gobs-project:gensvc
+docker push buoyantio/gobs-project:websvc
+docker push buoyantio/gobs-project:wordsvc
+```
+
+## Linkerd/Namerd Package Install
+
+### DC/OS Package Config
+
+#### linkerd
+
+`linkerd-package-options.json` is the linkerd DC/OS package install configuration. Package options of note:
+
+- `instances` - size of the DC/OS cluster, to ensure linkerd is installed on each node
+- `config-filename` - linkerd runtime configuration filename, appends to `config-uri`
+- `config-uri` - linkerd runtime configuration location, prepends to `config-filename`
+- `routing-port` - port to route rpc calls. must match the `routers/servers/port` specified in `linkerd-dcos-gob.yaml`
+
+#### namerd
+
+`namerd-package-options.json` is the namerd DC/OS package install configuration. Package options of note:
+
+- `config-filename` - namerd runtime configuration filename, appends to `config-uri`
+- `config-uri` - namerd runtime configuration location, prepends to `namerd-filename`
+- `http-port` - http control port, must match the `interfaces/httpController` port specified in `namerd-dcos-gob.yaml`
+- `thrift-port` - thrift interface port, must match:
+  - `interfaces/thriftNameInterpreter` port specified in `namerd-dcos-gob.yaml`
+  - `router/interpreter/dst` port specified in `linkerd-dcos-gob.yaml`
+- `resource-role` - the role to run namerd instances on.
+
+
+### linkerd Config
+
+`https://s3.amazonaws.com/buoyant-dcos/linkerd-dcos-gob.yaml` is the linkerd runtime configuration, customized for this Gob example:
+
+- linkerd routes all traffic via port `4140`. Services perform all RPC calls via localhost:4140.
+- The `baseDtab` section routes on host headers. Calling the word service looks like this:
+
+    ```bash
+    curl -H "Host: word" localhost:4140
+    ```
+
+- The `baseDtab` section defaults routing to the `web` service. An internet-facing load balancer should route traffic to localhost:4140 on the DC/OS public node, from there linkerd will route to `web`.
+
+### linkerd/namerd Package Install
+
+For the sake of this demonstration, assume $PUBLIC_URL is set to a public-facing mesos node.
+
+```bash
+export PUBLIC_URL=http://example.com
+```
+
+Upload you DC/OS config to a publicly accessible URL.
+
+```bash
+aws s3 cp dcos/linkerd-dcos-gob.yaml s3://buoyant-dcos --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+aws s3 cp dcos/namerd-dcos-gob.yaml s3://buoyant-dcos --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+```
+
+Add the linkerd universe repo to DC/OS
+
+```bash
+dcos package repo add linkerd https://github.com/buoyantio/universe/archive/siggy/linkerd.zip
+```
+
+Initialize Zookeeper path
+
+`namerd-dcos-gob.yaml` specifies a `storage/pathPrefix` for zk storage. Create this path in preparation for namerd installation.
+
+```bash
+ssh core@$PUBLIC_URL -L 2181:$PUBLIC_URL:2181 -N
+zkCli -server localhost:2181 create /dtabs null
+```
+
+Install the packages, via command line, or the DC/OS UI
+
+```bash
+dcos package install linkerd --options=dcos/linkerd-package-options.json
+dcos package install namerd --options=dcos/namerd-package-options.json
+```
+
+## Gob Deploy
+
+```bash
+dcos marathon app add dcos/marathon/gensvc.json
+dcos marathon app add dcos/marathon/wordsvc.json
+dcos marathon app add dcos/marathon/websvc.json
+```
+
+## Confirm it all works
+
+### Initialize namerd dtabs
+
+```bash
+curl -vX POST -d @dcos/namerd.dtab --header "Content-Type: application/dtab" $PUBLIC_URL:4180/api/1/dtabs/default
+open $PUBLIC_URL:4180/api/1/dtabs/default
+```
+
+### Update namerd dtabs
+
+```bash
+ETAG=`curl -i $PUBLIC_URL:4180/api/1/dtabs/default|grep -Fi ETag: | awk {'print $2'} | sed -e 's/[[:cntrl:]]//'`
+curl -vX PUT -d @dcos/namerd.dtab --header "Content-Type: application/dtab" --header "If-Match: $ETAG" $PUBLIC_URL:4180/api/1/dtabs/default
+open $PUBLIC_URL:4180/api/1/dtabs/default
+```
+
+### Test Gob app
+
+```bash
+curl "$PUBLIC_URL:4140/gob?text=foo&limit=2"
+```

--- a/dcos/linkerd-dcos-gob.yaml
+++ b/dcos/linkerd-dcos-gob.yaml
@@ -1,0 +1,15 @@
+admin:
+  port: 9990
+routers:
+- protocol: http
+  label: int
+  httpAccessLog: access.log
+  identifier:
+    kind: default
+    httpUriInDst: true
+  servers:
+  - port: 4140
+    ip: 0.0.0.0
+  interpreter:
+    kind: io.l5d.namerd
+    dst: /$/inet/namerd.marathon.slave.mesos/4100

--- a/dcos/linkerd-package-options.json
+++ b/dcos/linkerd-package-options.json
@@ -1,0 +1,12 @@
+{
+  "linkerd": {
+    "admin-port": 9990,
+    "config-filename": "linkerd-dcos-gob.yaml",
+    "config-uri": "https://s3.amazonaws.com/buoyant-dcos",
+    "cpus": 0.25,
+    "instances": 6,
+    "mem": 256.0,
+    "name": "linkerd",
+    "routing-port": 4140
+  }
+}

--- a/dcos/marathon/gensvc.json
+++ b/dcos/marathon/gensvc.json
@@ -1,0 +1,33 @@
+{
+  "id": "/gen",
+  "instances": 1,
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "buoyantio/gobs-project:gensvc",
+      "forcePullImage": false,
+      "network": "BRIDGE",
+      "portMappings": [
+        {
+          "containerPort": 0,
+          "hostPort": 0,
+          "servicePort": 0,
+          "protocol": "tcp"
+        }
+      ]
+    }
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/health"
+    }
+  ],
+  "cmd": "/usr/bin/gensvc --srv=:$PORT0",
+  "cpus": 0.25,
+  "mem": 256.0,
+  "uris": [
+    "file:///etc/docker.tar.gz"
+  ]
+}

--- a/dcos/marathon/websvc.json
+++ b/dcos/marathon/websvc.json
@@ -1,0 +1,33 @@
+{
+  "id": "/web",
+  "instances": 1,
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "buoyantio/gobs-project:websvc",
+      "forcePullImage": false,
+      "network": "BRIDGE",
+      "portMappings": [
+        {
+          "containerPort": 0,
+          "hostPort": 0,
+          "servicePort": 0,
+          "protocol": "tcp"
+        }
+      ]
+    }
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/"
+    }
+  ],
+  "cmd": "/usr/bin/websvc --srv=:$PORT0 --gen-addr=$HOST:4140 --word-addr=$HOST:4140",
+  "cpus": 0.25,
+  "mem": 256.0,
+  "uris": [
+    "file:///etc/docker.tar.gz"
+  ]
+}

--- a/dcos/marathon/wordsvc.json
+++ b/dcos/marathon/wordsvc.json
@@ -1,0 +1,33 @@
+{
+  "id": "/word",
+  "instances": 1,
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "buoyantio/gobs-project:wordsvc",
+      "forcePullImage": false,
+      "network": "BRIDGE",
+      "portMappings": [
+        {
+          "containerPort": 0,
+          "hostPort": 0,
+          "servicePort": 0,
+          "protocol": "tcp"
+        }
+      ]
+    }
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/"
+    }
+  ],
+  "cmd": "/usr/bin/wordsvc --srv=:$PORT0",
+  "cpus": 0.25,
+  "mem": 256.0,
+  "uris": [
+    "file:///etc/docker.tar.gz"
+  ]
+}

--- a/dcos/namerd-dcos-gob.yaml
+++ b/dcos/namerd-dcos-gob.yaml
@@ -1,0 +1,21 @@
+admin:
+  port: 9001
+storage:
+  kind: io.buoyant.namerd.storage.experimental.zk
+  hosts:
+  - master.mesos:2181
+  pathPrefix: /dtabs
+  sessionTimeoutMs: 10000
+namers:
+- kind:      io.l5d.experimental.marathon
+  prefix:    /io.l5d.marathon
+  host:      marathon.mesos
+  port:      80
+  uriPrefix: /marathon
+interfaces:
+- kind: thriftNameInterpreter
+  ip: 0.0.0.0
+  port: 4100
+- kind: httpController
+  ip: 0.0.0.0
+  port: 4180

--- a/dcos/namerd-package-options.json
+++ b/dcos/namerd-package-options.json
@@ -1,0 +1,14 @@
+{
+  "namerd": {
+    "admin-port": 9001,
+    "config-filename": "namerd-dcos-gob.yaml",
+    "config-uri": "https://s3.amazonaws.com/buoyant-dcos",
+    "cpus": 0.25,
+    "http-port": 4180,
+    "instances": 1,
+    "mem": 256.0,
+    "name": "namerd",
+    "resource-role": "slave_public",
+    "thrift-port": 4100
+  }
+}

--- a/dcos/namerd.dtab
+++ b/dcos/namerd.dtab
@@ -1,0 +1,6 @@
+/srv        => /io.l5d.marathon;
+/www        => /srv/web;
+/host       => /srv | /$/io.buoyant.http.anyHostPfx/www;
+/method     => /$/io.buoyant.http.anyMethodPfx/host;
+/http/1.1   => /method;
+/http/1.0   => /$/io.buoyant.http.anyMethodPfx/www;

--- a/gob/Dockerfile-fmtsvc
+++ b/gob/Dockerfile-fmtsvc
@@ -1,5 +1,0 @@
-FROM library/golang:1.6.0
-RUN ["mkdir", "-p", "/src"]
-COPY gob/fmtsvc.go /src/
-RUN ["go", "build", "-o", "/usr/bin/fmtsvc", "/src/fmtsvc.go"]
-ENTRYPOINT ["/usr/bin/fmtsvc"]

--- a/gob/Dockerfile-wordsvc
+++ b/gob/Dockerfile-wordsvc
@@ -1,0 +1,5 @@
+FROM library/golang:1.6.0
+RUN ["mkdir", "-p", "/src"]
+COPY gob/wordsvc.go /src/
+RUN ["go", "build", "-o", "/usr/bin/wordsvc", "/src/wordsvc.go"]
+ENTRYPOINT ["/usr/bin/wordsvc"]

--- a/gob/gensvc.go
+++ b/gob/gensvc.go
@@ -40,6 +40,16 @@ func (svc *GenSvc) ServeHTTP(rspw http.ResponseWriter, req *http.Request) {
 			return
 		}
 
+	case "/health":
+		switch req.Method {
+		case "GET":
+			return
+
+		default:
+			rspw.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+
 	default:
 		rspw.WriteHeader(http.StatusNotFound)
 		return


### PR DESCRIPTION
uses 1.7 universe packages, example install files,
added health check for gen service

running at:
- http://buoyant-d-publicsl-1wjj0rfusqjh3-462763067.us-west-1.elb.amazonaws.com:4140/gob?text=foo&limit=2
- http://buoyant-d-publicsl-1wjj0rfusqjh3-462763067.us-west-1.elb.amazonaws.com:4180/api/1/dtabs/default
- http://buoyant-d-publicsl-1wjj0rfusqjh3-462763067.us-west-1.elb.amazonaws.com:9990/

![screen shot 2016-03-30 at 6 34 18 pm](https://cloud.githubusercontent.com/assets/236915/14164433/88994376-f6b4-11e5-8830-e97c3529b075.png)
![screen shot 2016-03-30 at 6 36 46 pm](https://cloud.githubusercontent.com/assets/236915/14164436/901a1986-f6b4-11e5-87fe-54a5ba73b942.png)
![screen shot 2016-03-30 at 6 37 36 pm](https://cloud.githubusercontent.com/assets/236915/14164440/949b2874-f6b4-11e5-86ca-66fae01cb2a1.png)
![screen shot 2016-03-30 at 6 37 47 pm](https://cloud.githubusercontent.com/assets/236915/14164446/9a904e80-f6b4-11e5-9d68-9ef6e8cc3c7d.png)
![screen shot 2016-03-30 at 6 38 14 pm](https://cloud.githubusercontent.com/assets/236915/14164450/a0232372-f6b4-11e5-8a03-205caa22a58f.png)
![screen shot 2016-03-30 at 8 05 12 pm](https://cloud.githubusercontent.com/assets/236915/14164452/aac43c80-f6b4-11e5-883c-b05ed9595b7d.png)
