### PR TITLE
Prep for repo move to linkerd org

### DIFF
--- a/docker/helloworld/dockerize
+++ b/docker/helloworld/dockerize
@@ -7,7 +7,7 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-docker run --rm -v `pwd`:/go/src/github.com/buoyantio/linkerd-examples/docker/helloworld -w /go/src/github.com/buoyantio/linkerd-examples/docker/helloworld -e CGO_ENABLED=0 golang:1.8 go build -v
-docker run --rm -v `pwd`:/go/src/github.com/buoyantio/linkerd-examples/docker/helloworld -w /go/src/github.com/buoyantio/linkerd-examples/docker/helloworld/helloworld-client -e CGO_ENABLED=0 golang:1.8 go build -v
+docker run --rm -v `pwd`:/go/src/github.com/linkerd/linkerd-examples/docker/helloworld -w /go/src/github.com/linkerd/linkerd-examples/docker/helloworld -e CGO_ENABLED=0 golang:1.8 go build -v
+docker run --rm -v `pwd`:/go/src/github.com/linkerd/linkerd-examples/docker/helloworld -w /go/src/github.com/linkerd/linkerd-examples/docker/helloworld/helloworld-client -e CGO_ENABLED=0 golang:1.8 go build -v
 docker build -t buoyantio/helloworld:$1 .
 echo "Created buoyantio/helloworld:$1"

--- a/docker/helloworld/grpc/grpc.go
+++ b/docker/helloworld/grpc/grpc.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"time"
 
-	proto "github.com/buoyantio/linkerd-examples/docker/helloworld/proto"
+	proto "github.com/linkerd/linkerd-examples/docker/helloworld/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )

--- a/docker/helloworld/helloworld-client/main.go
+++ b/docker/helloworld/helloworld-client/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	proto "github.com/buoyantio/linkerd-examples/docker/helloworld/proto"
+	proto "github.com/linkerd/linkerd-examples/docker/helloworld/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 )

--- a/docker/helloworld/main.go
+++ b/docker/helloworld/main.go
@@ -9,9 +9,9 @@ import (
 	"os"
 	"time"
 
-	grpcServer "github.com/buoyantio/linkerd-examples/docker/helloworld/grpc"
-	httpServer "github.com/buoyantio/linkerd-examples/docker/helloworld/http"
-	proto "github.com/buoyantio/linkerd-examples/docker/helloworld/proto"
+	grpcServer "github.com/linkerd/linkerd-examples/docker/helloworld/grpc"
+	httpServer "github.com/linkerd/linkerd-examples/docker/helloworld/http"
+	proto "github.com/linkerd/linkerd-examples/docker/helloworld/proto"
 	"google.golang.org/grpc"
 )
 

--- a/docker/jenkins-plus/Dockerfile
+++ b/docker/jenkins-plus/Dockerfile
@@ -9,7 +9,7 @@ RUN mv go /usr/local
 ENV GOPATH /go
 RUN mkdir $GOPATH
 ENV PATH /usr/local/go/bin:$GOPATH/bin:$PATH
-RUN go get github.com/BuoyantIO/namerctl && go install github.com/BuoyantIO/namerctl
+RUN go get github.com/linkerd/namerctl && go install github.com/linkerd/namerctl
 ENV NAMERCTL_BASE_URL http://namerd.default.svc.cluster.local:4180
 
 USER jenkins

--- a/docker/jenkins-plus/jobs/hello_world/config.xml
+++ b/docker/jenkins-plus/jobs/hello_world/config.xml
@@ -9,7 +9,7 @@
         <hudson.model.StringParameterDefinition>
           <name>gitRepo</name>
           <description>linkerd-examples repo to clone and build</description>
-          <defaultValue>https://github.com/BuoyantIO/linkerd-examples</defaultValue>
+          <defaultValue>https://github.com/linkerd/linkerd-examples</defaultValue>
         </hudson.model.StringParameterDefinition>
         <hudson.model.StringParameterDefinition>
           <name>gitBranch</name>

--- a/getting-started/docker/README.md
+++ b/getting-started/docker/README.md
@@ -11,7 +11,7 @@ For more information on linkerd, please visit linkerd.io
 Start by cloning this repo:
 
 ```
-git clone https://github.com/BuoyantIO/linkerd-examples.git
+git clone https://github.com/linkerd/linkerd-examples.git
 cd linkerd-examples/getting-started/docker
 ```
 

--- a/getting-started/k8s/README.md
+++ b/getting-started/k8s/README.md
@@ -11,7 +11,7 @@ Start by cloning this repo.  Make sure that `kubectl` is installed and
 configured to talk to your Kubernetes cluster.
 
 ```
-git clone https://github.com/BuoyantIO/linkerd-examples.git
+git clone https://github.com/linkerd/linkerd-examples.git
 cd linkerd-examples/getting-started/k8s
 kubectl cluster-info
 ```

--- a/gob/Dockerfile
+++ b/gob/Dockerfile
@@ -1,7 +1,7 @@
 FROM library/golang:1.6.0
 
-ADD . /go/src/github.com/buoyantio/linkerd-examples/gob
+ADD . /go/src/github.com/linkerd/linkerd-examples/gob
 
-RUN ["go", "build", "-o", "/usr/bin/web", "/go/src/github.com/buoyantio/linkerd-examples/gob/src/web/main.go"]
-RUN ["go", "build", "-o", "/usr/bin/gen", "/go/src/github.com/buoyantio/linkerd-examples/gob/src/gen/main.go"]
-RUN ["go", "build", "-o", "/usr/bin/word", "/go/src/github.com/buoyantio/linkerd-examples/gob/src/word/main.go"]
+RUN ["go", "build", "-o", "/usr/bin/web", "/go/src/github.com/linkerd/linkerd-examples/gob/src/web/main.go"]
+RUN ["go", "build", "-o", "/usr/bin/gen", "/go/src/github.com/linkerd/linkerd-examples/gob/src/gen/main.go"]
+RUN ["go", "build", "-o", "/usr/bin/word", "/go/src/github.com/linkerd/linkerd-examples/gob/src/word/main.go"]

--- a/gob/dcos/README.md
+++ b/gob/dcos/README.md
@@ -42,7 +42,7 @@ dcos marathon app add dcos/marathon/websvc.json
 `namerctl` is utility for interacting with the namerd API from the commandline
 
 ```
-:; go install github.com/buoyantio/namerctl
+:; go install github.com/linkerd/namerctl
 :; namerctl -h
 ```
 

--- a/gob/k8s/README.md
+++ b/gob/k8s/README.md
@@ -28,8 +28,8 @@ interact with the namerd API from the commandline. If you have
 as:
 
 ```
-:; go get github.com/buoyantio/namerctl
-:; go install github.com/buoyantio/namerctl
+:; go get github.com/linkerd/namerctl
+:; go install github.com/linkerd/namerctl
 :; namerctl -h
 Find more information at https://linkerd.io
 

--- a/gob/src/gen/main.go
+++ b/gob/src/gen/main.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os"
 
-	pb "github.com/buoyantio/linkerd-examples/gob/proto"
+	pb "github.com/linkerd/linkerd-examples/gob/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 )

--- a/gob/src/web/main.go
+++ b/gob/src/web/main.go
@@ -11,7 +11,7 @@ import (
 	"text/template"
 	"time"
 
-	pb "github.com/buoyantio/linkerd-examples/gob/proto"
+	pb "github.com/linkerd/linkerd-examples/gob/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/gob/src/word/main.go
+++ b/gob/src/word/main.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"os"
 
-	pb "github.com/buoyantio/linkerd-examples/gob/proto"
+	pb "github.com/linkerd/linkerd-examples/gob/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/http-proxy/README.md
+++ b/http-proxy/README.md
@@ -12,7 +12,7 @@ echo "Hello world" > hello; python3 -m http.server 8888
 ## Setup linkerd
 
 ```bash
-curl -sLO https://github.com/BuoyantIO/linkerd/releases/download/0.9.0/linkerd-0.9.0-exec
+curl -sLO https://github.com/linkerd/linkerd/releases/download/0.9.0/linkerd-0.9.0-exec
 chmod +x linkerd-0.9.0-exec
 ./linkerd-0.9.0-exec ./linkerd.yaml
 ```

--- a/k8s-daemonset/README.md
+++ b/k8s-daemonset/README.md
@@ -164,10 +164,10 @@ kubectl apply -f k8s/hello-world-ingress.yml
 ### linkerd-viz
 
 And lastly, once you have linkerd deployed, you can deploy
-[linkerd-viz](https://github.com/BuoyantIO/linkerd-viz) as well, by running:
+[linkerd-viz](https://github.com/linkerd/linkerd-viz) as well, by running:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/BuoyantIO/linkerd-viz/master/k8s/linkerd-viz.yml
+kubectl apply -f https://raw.githubusercontent.com/linkerd/linkerd-viz/master/k8s/linkerd-viz.yml
 ```
 
 ## Verifying

--- a/linkerd-tcp/README.md
+++ b/linkerd-tcp/README.md
@@ -12,7 +12,7 @@ directory is configured to run the demo. Start everything with:
 $ docker-compose build && docker-compose up -d
 ```
 
-That command will start [linkerd-viz](https://github.com/BuoyantIO/linkerd-viz)
+That command will start [linkerd-viz](https://github.com/linkerd/linkerd-viz)
 on port 3000 on your Docker host, which you can use to view the demo in action.
 Set the `DOCKER_IP` environment variable to your Docker IP (e.g.
 `DOCKER_IP=$(docker-machine ip)`), and then open the dashboard with:
@@ -65,11 +65,11 @@ are collected by the linkerd-viz container and displayed on dashboards using
 
 Once the demo is up and running, you can shift traffic between the two redis
 clusters by updating the default routing rules that are stored in namerd. To do
-this, use the [namerctl](https://github.com/BuoyantIO/namerctl) command line
+this, use the [namerctl](https://github.com/linkerd/namerctl) command line
 utility. Install it with:
 
 ```bash
-$ go get -u github.com/buoyantio/namerctl
+$ go get -u github.com/linkerd/namerctl
 ```
 
 namerctl uses namerd's HTTP API, which is running on port 4180 on your Docker


### PR DESCRIPTION
Linkerd-examples is moving to the linkerd org. Will merge this after the move happens.