### PR TITLE
Upgrade plugins dependencies

### DIFF
--- a/plugins/build.sbt
+++ b/plugins/build.sbt
@@ -1,9 +1,9 @@
 
 def twitterUtil(mod: String) =
-  "com.twitter" %% s"util-$mod" %  "6.40.0"
+  "com.twitter" %% s"util-$mod" %  "6.43.0"
 
 def finagle(mod: String) =
-  "com.twitter" %% s"finagle-$mod" % "6.41.0"
+  "com.twitter" %% s"finagle-$mod" % "6.44.0"
 
 def linkerd(mod: String) =
   "io.buoyant" %% s"linkerd-$mod" % "1.0.2"
@@ -11,7 +11,7 @@ def linkerd(mod: String) =
 val headerClassifier =
   project.in(file("header-classifier")).
     settings(
-      scalaVersion := "2.11.7",
+      scalaVersion := "2.12.1",
       organization := "io.buoyant",
       name := "header-classifier",
       resolvers ++= Seq(

--- a/plugins/header-classifier/README.md
+++ b/plugins/header-classifier/README.md
@@ -21,7 +21,7 @@ This plugin is built with sbt.  Run sbt from the plugins directory.
 ```
 
 This will produce the plugin jar at
-`header-classifier/target/scala-2.11/header-classifier-assembly-0.1-SNAPSHOT.jar`.
+`header-classifier/target/scala-2.12/header-classifier-assembly-0.1-SNAPSHOT.jar`.
 
 ## Installing
 


### PR DESCRIPTION
Upgrade plugins dependencies to latest, so that they work with current
version of linkerd (1.0.2).

- Scala version: `2.11.7` -> `2.12.1`
- `"com.twitter" %% "util-core"`: `6.40.0` -> `6.43.0`
- `"com.twitter" %% "finagle-http"`: `6.41.0` -> `6.44.0`