### PR TITLE
Tweak egress dtab

### DIFF
--- a/k8s-daemonset/k8s/linkerd-egress.yaml
+++ b/k8s-daemonset/k8s/linkerd-egress.yaml
@@ -32,7 +32,7 @@ data:
       label: outgoing
       dtab: |
         /ph        => /$/io.buoyant.rinet ; # Lookup the name in DNS
-        /svc       => /ph/80 ; # Use port 80 if unspecified
+        /srv       => /ph/80 ; # Use port 80 if unspecified
         /srv       => /$/io.buoyant.porthostPfx/ph ; # Attempt to extract the port from the hostname
         /srv       => /#/io.l5d.k8s.ds/default/http ; # Lookup the name in Kubernetes, use the linkerd daemonset pod
         /svc       => /srv ;


### PR DESCRIPTION
A minor tweak to the egress dtab to make delegations more consistent and easy to understand.

The 3 `/srv` rules now correspond directly to the 3 delegation branches:

1. The linkerd daemonset pod of the Kubernetes service, if it exists
2. An external DNS service on the specified port
3. An external DNS service on port 80 if no port specified
