### PR TITLE
Istio ingress configs

### DIFF
--- a/istio/README.md
+++ b/istio/README.md
@@ -1,0 +1,26 @@
+# Enabling Ingress Traffic
+
+This doc details how to run the
+[ingress istio example](https://istio.io/docs/tasks/ingress.html) using linkerd
+ daemonsets as the istio proxy.
+
+1) Setup Istio by following the instructions in the
+[Installation guide](https://istio.io/docs/tasks/installing-istio.html).
+
+2) Deploy the linkerd daemonset:
+`kubectl apply -f istio-daemonset.yml`
+
+3) Replace the default istio ingress and egress controllers with linkerd-powered ones:
+`kubectl apply -f istio-ingress.yml`
+
+4) Start the httpbin sample, which will be used as the destination service to
+ be exposed externally. No need to use `istioctl kube-inject`. From the istio
+ project directory, run:
+`kubectl apply -f samples/apps/httpbin/httpbin.yaml`
+
+5) Follow istio instructions for configuring
+[HTTP ingress](https://istio.io/docs/tasks/ingress.html#configuring-ingress-http) or
+ [HTTPs ingress](https://istio.io/docs/tasks/ingress.html#configuring-secure-ingress-https).
+
+More information on ingress controllers can be found on the
+[Buoyant blog](https://blog.buoyant.io/2017/04/06/a-service-mesh-for-kubernetes-part-viii-linkerd-as-an-ingress-controller/).

--- a/istio/README.md
+++ b/istio/README.md
@@ -11,11 +11,10 @@ This doc details how to run the
 `kubectl apply -f istio-daemonset.yml`
 
 3) Replace the default istio ingress and egress controllers with linkerd-powered ones:
-`kubectl apply -f istio-ingress.yml`
+`kubectl apply -f istio-ingress.yml -f istio-egress.yml`
 
 4) Start the httpbin sample, which will be used as the destination service to
- be exposed externally. No need to use `istioctl kube-inject`. From the istio
- project directory, run:
+ be exposed externally. From the istio project directory, run:
 `kubectl apply -f samples/apps/httpbin/httpbin.yaml`
 
 5) Follow istio instructions for configuring
@@ -24,3 +23,17 @@ This doc details how to run the
 
 More information on ingress controllers can be found on the
 [Buoyant blog](https://blog.buoyant.io/2017/04/06/a-service-mesh-for-kubernetes-part-viii-linkerd-as-an-ingress-controller/).
+
+# Enabling Egress Traffic
+
+1) Setup Istio by following the instructions in the
+[Installation guide](https://istio.io/docs/tasks/installing-istio.html).
+
+2) Deploy the linkerd daemonset:
+`kubectl apply -f istio-daemonset.yml`
+
+3) Replace the default istio ingress and egress controllers with linkerd-powered ones:
+`kubectl apply -f istio-ingress.yml -f istio-egress.yml`
+
+4) Calls to outside the cluster are now possible (ExternalName services not
+ yet supported).

--- a/istio/istio-daemonset.yml
+++ b/istio/istio-daemonset.yml
@@ -70,7 +70,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.0-SNAPSHOT
+        image: buoyantio/linkerd:1.1.1-rc1
         env:
         - name: POD_IP
           valueFrom:

--- a/istio/istio-daemonset.yml
+++ b/istio/istio-daemonset.yml
@@ -1,0 +1,124 @@
+# runs linkerd in a daemonset, in linker-to-linker mode
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: l5d-config
+data:
+  config.yaml: |-
+    admin:
+      port: 9990
+
+    namers:
+    - kind: io.l5d.k8s
+      experimental: true
+      host: localhost
+      port: 8001
+
+    telemetry:
+    - kind: io.l5d.prometheus
+    - kind: io.l5d.recentRequests
+      sampleRate: 0.25
+
+    routers:
+    - protocol: http
+      label: outgoing
+      identifier:
+        kind: io.l5d.istio
+        apiserverHost: istio-pilot
+        discoveryHost: istio-pilot
+      interpreter:
+        kind: io.l5d.k8s.istio
+        experimental: true
+        discoveryHost: istio-pilot
+        apiserverHost: istio-pilot
+        transformers:
+        - kind: io.l5d.k8s.daemonset
+          namespace: default
+          port: incoming
+          service: l5d
+      servers:
+      - port: 4140
+        ip: 0.0.0.0
+      service:
+        responseClassifier:
+          kind: io.l5d.http.retryableRead5XX
+
+    - protocol: http
+      label: incoming
+      identifier:
+        kind: io.l5d.istio
+        apiserverHost: istio-pilot
+        discoveryHost: istio-pilot
+      interpreter:
+        kind: io.l5d.k8s.istio
+        experimental: true
+        discoveryHost: istio-pilot
+        apiserverHost: istio-pilot
+        transformers:
+        - kind: io.l5d.k8s.localnode
+      servers:
+      - port: 4141
+        ip: 0.0.0.0
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: l5d
+  name: l5d
+spec:
+  template:
+    metadata:
+      labels:
+        app: l5d
+    spec:
+      volumes:
+      - name: l5d-config
+        configMap:
+          name: "l5d-config"
+      containers:
+      - name: l5d
+        image: buoyantio/linkerd:1.1.0-SNAPSHOT
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        args:
+        - /io.buoyant/linkerd/config/config.yaml
+        ports:
+        - name: outgoing
+          containerPort: 4140
+          hostPort: 4140
+        - name: incoming
+          containerPort: 4141
+        - name: admin
+          containerPort: 9990
+        volumeMounts:
+        - name: "l5d-config"
+          mountPath: "/io.buoyant/linkerd/config"
+          readOnly: true
+
+      - name: kubectl
+        image: buoyantio/kubectl:v1.4.0
+        args:
+        - "proxy"
+        - "-p"
+        - "8001"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: l5d
+spec:
+  selector:
+    app: l5d
+  type: LoadBalancer
+  ports:
+  - name: outgoing
+    port: 4140
+  - name: incoming
+    port: 4141
+  - name: admin
+    port: 9990

--- a/istio/istio-daemonset.yml
+++ b/istio/istio-daemonset.yml
@@ -70,7 +70,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.1-rc1
+        image: buoyantio/linkerd:1.1.1
         env:
         - name: POD_IP
           valueFrom:

--- a/istio/istio-daemonset.yml
+++ b/istio/istio-daemonset.yml
@@ -23,6 +23,9 @@ data:
     routers:
     - protocol: http
       label: outgoing
+      loggers:
+      - kind: io.l5d.istio
+        mixerHost: istio-mixer
       identifier:
         kind: io.l5d.istio
       interpreter:

--- a/istio/istio-daemonset.yml
+++ b/istio/istio-daemonset.yml
@@ -25,13 +25,9 @@ data:
       label: outgoing
       identifier:
         kind: io.l5d.istio
-        apiserverHost: istio-pilot
-        discoveryHost: istio-pilot
       interpreter:
         kind: io.l5d.k8s.istio
         experimental: true
-        discoveryHost: istio-pilot
-        apiserverHost: istio-pilot
         transformers:
         - kind: io.l5d.k8s.daemonset
           namespace: default
@@ -85,6 +81,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:

--- a/istio/istio-daemonset.yml
+++ b/istio/istio-daemonset.yml
@@ -9,12 +9,6 @@ data:
     admin:
       port: 9990
 
-    namers:
-    - kind: io.l5d.k8s
-      experimental: true
-      host: localhost
-      port: 8001
-
     telemetry:
     - kind: io.l5d.prometheus
     - kind: io.l5d.recentRequests
@@ -24,10 +18,10 @@ data:
     - protocol: http
       label: outgoing
       loggers:
-      - kind: io.l5d.istio
+      - kind: io.l5d.k8s.istio
         mixerHost: istio-mixer
       identifier:
-        kind: io.l5d.istio
+        kind: io.l5d.k8s.istio
       interpreter:
         kind: io.l5d.k8s.istio
         experimental: true
@@ -46,14 +40,10 @@ data:
     - protocol: http
       label: incoming
       identifier:
-        kind: io.l5d.istio
-        apiserverHost: istio-pilot
-        discoveryHost: istio-pilot
+        kind: io.l5d.k8s.istio
       interpreter:
         kind: io.l5d.k8s.istio
         experimental: true
-        discoveryHost: istio-pilot
-        apiserverHost: istio-pilot
         transformers:
         - kind: io.l5d.k8s.localnode
       servers:

--- a/istio/istio-daemonset.yml
+++ b/istio/istio-daemonset.yml
@@ -1,5 +1,7 @@
-# runs linkerd in a daemonset, in linker-to-linker mode
 ---
+################################
+# Linkerd Daemonset
+################################
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/istio/istio-egress.yml
+++ b/istio/istio-egress.yml
@@ -52,7 +52,7 @@ spec:
           name: "istio-egress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.1-rc1
+        image: buoyantio/linkerd:1.1.1
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:

--- a/istio/istio-egress.yml
+++ b/istio/istio-egress.yml
@@ -1,4 +1,7 @@
 ---
+################################
+# Istio egress Linkerd
+################################
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/istio/istio-egress.yml
+++ b/istio/istio-egress.yml
@@ -52,7 +52,7 @@ spec:
           name: "istio-egress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.0-SNAPSHOT
+        image: buoyantio/linkerd:1.1.1-rc1
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:

--- a/istio/istio-egress.yml
+++ b/istio/istio-egress.yml
@@ -1,0 +1,84 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-egress-config
+data:
+  config.yaml: |-
+    admin:
+      port: 9990
+
+    telemetry:
+    - kind: io.l5d.prometheus
+    - kind: io.l5d.recentRequests
+      sampleRate: 0.25
+
+    routers:
+    - protocol: http
+      dtab: |
+        /ph        => /$/io.buoyant.rinet ; # Lookup the name in DNS
+        /svc       => /ph/80 ; # Use port 80 if unspecified
+        /srv       => /$/io.buoyant.porthostPfx/ph ;
+        /svc       => /srv ;
+      servers:
+      - port: 80
+        ip: 0.0.0.0
+      client:
+        kind: io.l5d.static
+        configs:
+        - prefix: "/$/io.buoyant.rinet/443/{service}"
+          tls:
+            commonName: "{service}"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-egress
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: ignore
+      labels:
+        istio: egress
+    spec:
+      volumes:
+      - name: istio-egress-config
+        configMap:
+          name: "istio-egress-config"
+      containers:
+      - name: l5d
+        image: buoyantio/linkerd:1.1.0-SNAPSHOT
+        args:
+        - /io.buoyant/linkerd/config/config.yaml
+        ports:
+        - name: incoming
+          containerPort: 80
+        - name: admin
+          containerPort: 9990
+        volumeMounts:
+        - name: "istio-egress-config"
+          mountPath: "/io.buoyant/linkerd/config"
+          readOnly: true
+
+      - name: kubectl
+        image: buoyantio/kubectl:v1.6.2
+        args:
+        - "proxy"
+        - "-p"
+        - "8001"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-egress
+spec:
+  selector:
+    istio: egress
+  type: LoadBalancer
+  ports:
+  - name: incoming
+    port: 80
+  - name: admin
+    port: 9990

--- a/istio/istio-ingress.yml
+++ b/istio/istio-ingress.yml
@@ -1,4 +1,7 @@
 ---
+################################
+# Istio ingress controller
+################################
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/istio/istio-ingress.yml
+++ b/istio/istio-ingress.yml
@@ -13,14 +13,13 @@ data:
     routers:
     - protocol: http
       identifier:
-        kind: io.l5d.istio-ingress
-        apiserverHost: istio-pilot
-        discoveryHost: istio-pilot
+        kind: io.l5d.k8s.istio-ingress
       interpreter:
         kind: io.l5d.k8s.istio
         experimental: true
-        discoveryHost: istio-pilot
-        apiserverHost: istio-pilot
+      loggers:
+      - kind: io.l5d.k8s.istio
+        mixerHost: istio-mixer
       servers:
         - port: 80
           ip: 0.0.0.0

--- a/istio/istio-ingress.yml
+++ b/istio/istio-ingress.yml
@@ -48,7 +48,7 @@ spec:
           name: "istio-ingress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.1-rc1
+        image: buoyantio/linkerd:1.1.1
         env:
         - name: POD_IP
           valueFrom:

--- a/istio/istio-ingress.yml
+++ b/istio/istio-ingress.yml
@@ -48,7 +48,7 @@ spec:
           name: "istio-ingress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.0-SNAPSHOT
+        image: buoyantio/linkerd:1.1.1-rc1
         env:
         - name: POD_IP
           valueFrom:

--- a/istio/istio-ingress.yml
+++ b/istio/istio-ingress.yml
@@ -1,0 +1,88 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-ingress-config
+data:
+  config.yaml: |-
+    telemetry:
+    - kind: io.l5d.prometheus
+    - kind: io.l5d.recentRequests
+      sampleRate: 0.25
+
+    routers:
+    - protocol: http
+      identifier:
+        kind: io.l5d.istio-ingress
+        apiserverHost: istio-pilot
+        discoveryHost: istio-pilot
+      interpreter:
+        kind: io.l5d.k8s.istio
+        experimental: true
+        discoveryHost: istio-pilot
+        apiserverHost: istio-pilot
+      servers:
+        - port: 80
+          ip: 0.0.0.0
+          clearContext: true
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-ingress
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: ignore
+      labels:
+        istio: ingress
+    spec:
+      serviceAccountName: istio-ingress-service-account
+      volumes:
+      - name: istio-ingress-config
+        configMap:
+          name: "istio-ingress-config"
+      containers:
+      - name: l5d
+        image: buoyantio/linkerd:1.1.0-SNAPSHOT
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        args:
+        - /io.buoyant/linkerd/config/config.yaml
+        ports:
+        - name: http
+          containerPort: 80
+        - name: admin
+          containerPort: 9990
+        volumeMounts:
+        - name: "istio-ingress-config"
+          mountPath: "/io.buoyant/linkerd/config"
+          readOnly: true
+
+      - name: kubectl
+        image: buoyantio/kubectl:v1.6.2
+        args: ["proxy", "-p", "8001"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-ingress
+spec:
+  selector:
+    istio: ingress
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+  - name: admin
+    port: 9990
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-ingress-service-account

--- a/istio/istio-linkerd.yml
+++ b/istio/istio-linkerd.yml
@@ -1,0 +1,420 @@
+# GENERATED FILE. Use with Kubernetes 1.5+
+# TO UPDATE, modify files in istio/ and run ./updateVersion.sh
+################################
+# Mixer
+################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-mixer
+  labels:
+    istio: mixer
+spec:
+  ports:
+  - name: tcp
+    port: 9091
+  - name: configapi
+    port: 9094
+  - name: prometheus
+    port: 42422
+  selector:
+    istio: mixer
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-mixer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: ignore
+      labels:
+        istio: mixer
+    spec:
+      containers:
+      - name: mixer
+        image: docker.io/istio/mixer:0.1.6
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9091
+        - containerPort: 9094
+        - containerPort: 42422
+        args:
+          - --configStoreURL=fs:///etc/opt/mixer/configroot
+          - --logtostderr
+          - -v
+          - "3"
+---
+################################
+# Pilot
+################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio
+data:
+  mesh: |-
+    # Uncomment the following line to enable mutual TLS between proxies
+    # authPolicy: MUTUAL_TLS
+    mixerAddress: istio-mixer:9091
+    discoveryAddress: istio-pilot:8080
+    ingressService: istio-ingress
+    zipkinAddress: zipkin:9411
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-pilot
+  labels:
+    istio: pilot
+spec:
+  ports:
+  - port: 8080
+    name: http-discovery
+  - port: 8081
+    name: http-apiserver
+  selector:
+    istio: pilot
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-pilot-service-account
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-pilot
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: ignore
+      labels:
+        istio: pilot
+    spec:
+      serviceAccountName: istio-pilot-service-account
+      containers:
+      - name: discovery
+        image: docker.io/istio/pilot:0.1.6
+        imagePullPolicy: Always
+        args: ["discovery", "-v", "2"]
+        ports:
+        - containerPort: 8080
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+      - name: apiserver
+        image: docker.io/istio/pilot:0.1.6
+        imagePullPolicy: Always
+        args: ["apiserver", "-v", "2"]
+        ports:
+        - containerPort: 8081
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+---
+################################
+# Linkerd Daemonset
+################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: l5d-config
+data:
+  config.yaml: |-
+    admin:
+      port: 9990
+
+    telemetry:
+    - kind: io.l5d.prometheus
+    - kind: io.l5d.recentRequests
+      sampleRate: 0.25
+
+    routers:
+    - protocol: http
+      label: outgoing
+      loggers:
+      - kind: io.l5d.k8s.istio
+        mixerHost: istio-mixer
+      identifier:
+        kind: io.l5d.k8s.istio
+      interpreter:
+        kind: io.l5d.k8s.istio
+        experimental: true
+        transformers:
+        - kind: io.l5d.k8s.daemonset
+          namespace: default
+          port: incoming
+          service: l5d
+      servers:
+      - port: 4140
+        ip: 0.0.0.0
+      service:
+        responseClassifier:
+          kind: io.l5d.http.retryableRead5XX
+
+    - protocol: http
+      label: incoming
+      identifier:
+        kind: io.l5d.k8s.istio
+      interpreter:
+        kind: io.l5d.k8s.istio
+        experimental: true
+        transformers:
+        - kind: io.l5d.k8s.localnode
+      servers:
+      - port: 4141
+        ip: 0.0.0.0
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: l5d
+  name: l5d
+spec:
+  template:
+    metadata:
+      labels:
+        app: l5d
+    spec:
+      volumes:
+      - name: l5d-config
+        configMap:
+          name: "l5d-config"
+      containers:
+      - name: l5d
+        image: buoyantio/linkerd:1.1.0-SNAPSHOT
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        args:
+        - /io.buoyant/linkerd/config/config.yaml
+        ports:
+        - name: outgoing
+          containerPort: 4140
+          hostPort: 4140
+        - name: incoming
+          containerPort: 4141
+        - name: admin
+          containerPort: 9990
+        volumeMounts:
+        - name: "l5d-config"
+          mountPath: "/io.buoyant/linkerd/config"
+          readOnly: true
+
+      - name: kubectl
+        image: buoyantio/kubectl:v1.4.0
+        args:
+        - "proxy"
+        - "-p"
+        - "8001"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: l5d
+spec:
+  selector:
+    app: l5d
+  type: LoadBalancer
+  ports:
+  - name: outgoing
+    port: 4140
+  - name: incoming
+    port: 4141
+  - name: admin
+    port: 9990
+---
+################################
+# Istio ingress controller
+################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-ingress-config
+data:
+  config.yaml: |-
+    telemetry:
+    - kind: io.l5d.prometheus
+    - kind: io.l5d.recentRequests
+      sampleRate: 0.25
+
+    routers:
+    - protocol: http
+      identifier:
+        kind: io.l5d.k8s.istio-ingress
+      interpreter:
+        kind: io.l5d.k8s.istio
+        experimental: true
+      loggers:
+      - kind: io.l5d.k8s.istio
+        mixerHost: istio-mixer
+      servers:
+        - port: 80
+          ip: 0.0.0.0
+          clearContext: true
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-ingress
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: ignore
+      labels:
+        istio: ingress
+    spec:
+      serviceAccountName: istio-ingress-service-account
+      volumes:
+      - name: istio-ingress-config
+        configMap:
+          name: "istio-ingress-config"
+      containers:
+      - name: l5d
+        image: buoyantio/linkerd:1.1.0-SNAPSHOT
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        args:
+        - /io.buoyant/linkerd/config/config.yaml
+        ports:
+        - name: http
+          containerPort: 80
+        - name: admin
+          containerPort: 9990
+        volumeMounts:
+        - name: "istio-ingress-config"
+          mountPath: "/io.buoyant/linkerd/config"
+          readOnly: true
+
+      - name: kubectl
+        image: buoyantio/kubectl:v1.6.2
+        args: ["proxy", "-p", "8001"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-ingress
+spec:
+  selector:
+    istio: ingress
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+  - name: admin
+    port: 9990
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-ingress-service-account
+---
+################################
+# Istio egress Linkerd
+################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-egress-config
+data:
+  config.yaml: |-
+    admin:
+      port: 9990
+
+    telemetry:
+    - kind: io.l5d.prometheus
+    - kind: io.l5d.recentRequests
+      sampleRate: 0.25
+
+    routers:
+    - protocol: http
+      dtab: |
+        /ph        => /$/io.buoyant.rinet ; # Lookup the name in DNS
+        /svc       => /ph/80 ; # Use port 80 if unspecified
+        /srv       => /$/io.buoyant.porthostPfx/ph ;
+        /svc       => /srv ;
+      servers:
+      - port: 80
+        ip: 0.0.0.0
+      client:
+        kind: io.l5d.static
+        configs:
+        - prefix: "/$/io.buoyant.rinet/443/{service}"
+          tls:
+            commonName: "{service}"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-egress
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: ignore
+      labels:
+        istio: egress
+    spec:
+      volumes:
+      - name: istio-egress-config
+        configMap:
+          name: "istio-egress-config"
+      containers:
+      - name: l5d
+        image: buoyantio/linkerd:1.1.0-SNAPSHOT
+        args:
+        - /io.buoyant/linkerd/config/config.yaml
+        ports:
+        - name: incoming
+          containerPort: 80
+        - name: admin
+          containerPort: 9990
+        volumeMounts:
+        - name: "istio-egress-config"
+          mountPath: "/io.buoyant/linkerd/config"
+          readOnly: true
+
+      - name: kubectl
+        image: buoyantio/kubectl:v1.6.2
+        args:
+        - "proxy"
+        - "-p"
+        - "8001"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-egress
+spec:
+  selector:
+    istio: egress
+  type: LoadBalancer
+  ports:
+  - name: incoming
+    port: 80
+  - name: admin
+    port: 9990

--- a/istio/istio-linkerd.yml
+++ b/istio/istio-linkerd.yml
@@ -194,7 +194,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.0-SNAPSHOT
+        image: buoyantio/linkerd:1.1.1-rc1
         env:
         - name: POD_IP
           valueFrom:
@@ -291,7 +291,7 @@ spec:
           name: "istio-ingress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.0-SNAPSHOT
+        image: buoyantio/linkerd:1.1.1-rc1
         env:
         - name: POD_IP
           valueFrom:
@@ -385,7 +385,7 @@ spec:
           name: "istio-egress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.0-SNAPSHOT
+        image: buoyantio/linkerd:1.1.1-rc1
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:

--- a/istio/istio-linkerd.yml
+++ b/istio/istio-linkerd.yml
@@ -194,7 +194,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.1-rc1
+        image: buoyantio/linkerd:1.1.1
         env:
         - name: POD_IP
           valueFrom:
@@ -291,7 +291,7 @@ spec:
           name: "istio-ingress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.1-rc1
+        image: buoyantio/linkerd:1.1.1
         env:
         - name: POD_IP
           valueFrom:
@@ -385,7 +385,7 @@ spec:
           name: "istio-egress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.1-rc1
+        image: buoyantio/linkerd:1.1.1
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:

--- a/istio/mixer-pilot.yml
+++ b/istio/mixer-pilot.yml
@@ -1,0 +1,122 @@
+################################
+# Mixer
+################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-mixer
+  labels:
+    istio: mixer
+spec:
+  ports:
+  - name: tcp
+    port: 9091
+  - name: configapi
+    port: 9094
+  - name: prometheus
+    port: 42422
+  selector:
+    istio: mixer
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-mixer
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: ignore
+      labels:
+        istio: mixer
+    spec:
+      containers:
+      - name: mixer
+        image: docker.io/istio/mixer:0.1.6
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9091
+        - containerPort: 9094
+        - containerPort: 42422
+        args:
+          - --configStoreURL=fs:///etc/opt/mixer/configroot
+          - --logtostderr
+          - -v
+          - "3"
+---
+################################
+# Pilot
+################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio
+data:
+  mesh: |-
+    # Uncomment the following line to enable mutual TLS between proxies
+    # authPolicy: MUTUAL_TLS
+    mixerAddress: istio-mixer:9091
+    discoveryAddress: istio-pilot:8080
+    ingressService: istio-ingress
+    zipkinAddress: zipkin:9411
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-pilot
+  labels:
+    istio: pilot
+spec:
+  ports:
+  - port: 8080
+    name: http-discovery
+  - port: 8081
+    name: http-apiserver
+  selector:
+    istio: pilot
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-pilot-service-account
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-pilot
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: ignore
+      labels:
+        istio: pilot
+    spec:
+      serviceAccountName: istio-pilot-service-account
+      containers:
+      - name: discovery
+        image: docker.io/istio/pilot:0.1.6
+        imagePullPolicy: Always
+        args: ["discovery", "-v", "2"]
+        ports:
+        - containerPort: 8080
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+      - name: apiserver
+        image: docker.io/istio/pilot:0.1.6
+        imagePullPolicy: Always
+        args: ["apiserver", "-v", "2"]
+        ports:
+        - containerPort: 8081
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace

--- a/istio/updateVersion.sh
+++ b/istio/updateVersion.sh
@@ -1,0 +1,15 @@
+# Derived from https://github.com/istio/istio/blob/master/install/updateVersion.sh
+
+function merge_files() {
+  ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  ISTIO=$ROOT/istio-linkerd.yml
+
+  echo "# GENERATED FILE. Use with Kubernetes 1.5+" > $ISTIO
+  echo "# TO UPDATE, modify files in istio/ and run ./updateVersion.sh" >> $ISTIO
+  cat $ROOT/mixer-pilot.yml >> $ISTIO
+  cat $ROOT/istio-daemonset.yml >> $ISTIO
+  cat $ROOT/istio-ingress.yml >> $ISTIO
+  cat $ROOT/istio-egress.yml >> $ISTIO
+}
+
+merge_files


### PR DESCRIPTION
Adds istio-specific configuration for daemonsets and ingress.
PR cannot be merged until the linkerd configs are moved off of snapshot versions.