### PR TITLE
nodeName test for k8s clusters

### DIFF
--- a/k8s-daemonset/k8s/node-name-test.yml
+++ b/k8s-daemonset/k8s/node-name-test.yml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: node-name
+spec:
+  template:
+    metadata:
+      name: pi
+    spec:
+      restartPolicy: Never
+      containers:
+      - image: arussellsaw/test:latest
+        name: node-name
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName

--- a/k8s-daemonset/k8s/node-name-test.yml
+++ b/k8s-daemonset/k8s/node-name-test.yml
@@ -1,18 +1,15 @@
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: Pod
 metadata:
-  name: node-name
+  name: node-name-test
 spec:
-  template:
-    metadata:
-      name: pi
-    spec:
-      restartPolicy: Never
-      containers:
-      - image: arussellsaw/test:latest
-        name: node-name
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
+  restartPolicy: Never
+  containers:
+  - image: tutum/dnsutils:latest
+    command: ["nslookup", "$(NODE_NAME)"]
+    name: node-name
+    env:
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName


### PR DESCRIPTION
Goal: improved documentation.

The `arussellsaw/test:latest` image logs nodeName and we use that to determine which hello-world app to run. Example of documentation:

Now we’ll install the hello and world apps in the default namespace. These apps rely on the nodeName supplied by the Kubernetes downward API to find Linkerd. To check if your cluster supports nodeName, you can run this test job:
```
kubectl apply -f https://raw.githubusercontent.com/linkerd/linkerd-examples/master/k8s-daemonset/k8s/node-name-test.yml
```
And then looks at its logs:
```
kubectl logs node-name-test
```
If you see an ip, great! Go ahead and deploy the hello world app using:
```
kubectl apply -f https://raw.githubusercontent.com/linkerd/linkerd-examples/master/k8s-daemonset/k8s/hello-world.yml
```
If instead you get a “no hosts” error, deploy the hello-world legacy version that relies on hostIP instead of nodeName:
```
kubectl apply -f https://raw.githubusercontent.com/linkerd/linkerd-examples/master/k8s-daemonset/k8s/hello-world-legacy.yml
```
At this point, we actually have a functioning service mesh and an application that makes use of it. You can see the entire setup in action by sending traffic through linkerd’s external IP:
```
$ curl $L5D_INGRESS_LB
Hello (10.196.2.5) world (10.196.2.6)!!
```
Or to use hostIP directly:
```
$ L5D_INGRESS_LB=$L5D_HOST_IP:$(kubectl get svc l5d -o 'jsonpath={.spec.ports[0].nodePort}')
$ curl $L5D_INGRESS_LB  Hello (10.196.2.5) world (10.196.2.6)!!
```
If everything is working, you’ll see a “Hello world” message similar to that above, with the IPs of the pods that served the request.