### PR TITLE
linkerd example configs for marathon auth

### DIFF
--- a/dcos/linkerd-marathon-auth/linkerd-config.yml
+++ b/dcos/linkerd-marathon-auth/linkerd-config.yml
@@ -1,0 +1,36 @@
+# linkerd config for basic http proxy
+# listens on port 4140, routes via http_proxy or host header
+# configured to connect to DC/OS in Strict mode, via Marathon TLS
+
+admin:
+  port: 9990
+
+telemetry:
+- kind: io.l5d.prometheus
+
+# This section is specific to DC/OS in Strict mode. linkerd's Marathon namer
+# connects to Marathon via TLS on port 443.
+namers:
+- kind: io.l5d.marathon
+  host: leader.mesos
+  port: 443
+  prefix: "/io.l5d.marathon"
+  uriPrefix: "/marathon"
+  tls:
+    disableValidation: false
+    commonName: master.mesos
+    trustCerts:
+    # This certificate should be available on Mesos Master. From within a
+    # container, the path should also be available via the
+    # LIBPROCESS_SSL_CA_FILE environment variable.
+    - /mnt/mesos/sandbox/.ssl/ca.crt
+
+routers:
+- protocol: http
+  servers:
+  - port: 4140
+    ip: 0.0.0.0
+  dtab: >- # route based on marathon name
+    /marathonId => /#/io.l5d.marathon;
+    /svc        => /$/io.buoyant.http.domainToPathPfx/marathonId;
+  label: linkerd_proxy

--- a/dcos/linkerd-marathon-auth/linkerd-dcos.json
+++ b/dcos/linkerd-marathon-auth/linkerd-dcos.json
@@ -1,0 +1,45 @@
+{
+  "id": "linkerd",
+  "instances": 4,
+  "cpus": 0.25,
+  "mem": 256.0,
+  "acceptedResourceRoles": ["*", "slave_public"],
+  "constraints": [["hostname", "UNIQUE"]],
+  "container": {
+    "type": "DOCKER",
+    "docker": {
+      "image": "buoyantio/linkerd:1.1.2",
+      "network": "HOST",
+      "privileged": true
+    }
+  },
+  "healthChecks": [
+    {
+      "protocol": "HTTP",
+      "portIndex": 0,
+      "path": "/admin/ping"
+    }
+  ],
+  "portDefinitions": [
+    {
+      "port": 9990,
+      "protocol": "tcp",
+      "name": "admin"
+    },
+    {
+      "port": 4140,
+      "protocol": "tcp",
+      "name": "proxy"
+    }
+  ],
+  "env": {
+    "DCOS_SERVICE_ACCOUNT_CREDENTIAL": { "secret": "serviceCredential" }
+  },
+  "secrets": {
+    "serviceCredential": {
+      "source": "linkerd-secret"
+    }
+  },
+  "requirePorts": true,
+  "cmd": "echo \"{\\\"admin\\\":{\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"leader.mesos\\\",\\\"port\\\":443,\\\"prefix\\\":\\\"/io.l5d.marathon\\\",\\\"uriPrefix\\\":\\\"/marathon\\\",\\\"tls\\\":{\\\"disableValidation\\\":false,\\\"commonName\\\":\\\"master.mesos\\\",\\\"trustCerts\\\":[\\\"/mnt/mesos/sandbox/.ssl/ca.crt\\\"]}}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.1.2/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
+}


### PR DESCRIPTION
relates to linkerd/linkerd#1497