### PR TITLE
gob/k8s: Use l5d-dtab instead of Dtab-local header

### DIFF
--- a/gob/k8s/README.md
+++ b/gob/k8s/README.md
@@ -236,7 +236,7 @@ We can test out our staged service (without altering the web service
 at all), by adding a delegation (routing rule) to a request.  For example:
 
 ```
-:; curl -H 'Dtab-local: /srv/gen => /srv/gen-growthhack' "$GOB_HOST/gob?text=gob&limit=10"
+:; curl -H 'l5d-dtab: /srv/gen => /srv/gen-growthhack' "$GOB_HOST/gob?text=gob&limit=10"
 gob <3 k8s
 gob <3 k8s
 gob <3 k8s


### PR DESCRIPTION
According to the author of https://github.com/linkerd/linkerd/issues/1188
Dtab-local is not supposed to work anymore