### PR TITLE
ECS+linkerd+Consul example setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,21 @@ information:
 * [Getting Started: Running in DC/OS](https://linkerd.io/getting-started/dcos/)
 * [linkerd on DC/OS for Service Discovery and Visibility](https://blog.buoyant.io/2016/10/10/linkerd-on-dcos-for-service-discovery-and-visibility/)
 
-
 ## Docker
 
 * [`docker/`](docker/)
 
 Contains files and scripts for building custom Docker images that are used in
 some of the examples in this repo.
+
+## Amazon ECS
+
+* [`ecs/`](ecs/)
+
+Provides common configurations for deploying linkerd to Amazon ECS. More
+information:
+
+* [Getting Started: Running in ECS](https://linkerd.io/getting-started/ecs/)
 
 ## Failure accrual demo
 
@@ -89,6 +97,15 @@ Sets up a demo environment that configures a
 linkerd, Telegraf, InfluxDB, and Grafana. Provides helpful configuration files
 and dashboards for all components.
 
+## Istio
+
+* [`istio/`](istio/)
+
+Provides common configurations for deploying linkerd to Istio. More information:
+
+* [Getting Started: Running with Istio](https://linkerd.io/getting-started/istio/)
+* [Linkerd and Istio: Like Peanut Butter and Jelly](https://buoyant.io/2017/07/11/linkerd-istio/)
+
 ## A Service Mesh for Kubernetes
 
 * [`k8s-daemonset/`](k8s-daemonset/)
@@ -122,7 +139,6 @@ without DC/OS.
 Contains sample code for building linkerd plugins. More information:
 
 * [In Depth: Plugins](https://linkerd.io/in-depth/plugin/)
-
 
 ## Testing
 

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -104,12 +104,16 @@ ECS_NODE=$( \
 http_proxy=$ECS_NODE:4140 curl hello
 Hello (172.31.20.160) World (172.31.19.35)!!
 
+# test dynamic routing to world-v2
+http_proxy=$ECS_NODE:4140 curl -H 'l5d-dtab: /svc/world => /svc/world-v2' hello
+Hello (172.31.20.160) World-V2 (172.31.19.35)!!
+
 # view linkerd and Consul UIs (osx)
 open http://$ECS_NODE:9990
 open http://$ECS_NODE:8500
 ```
 
-### linkerd-viz
+## linkerd-viz
 
 Put some load on our example app
 

--- a/ecs/README.md
+++ b/ecs/README.md
@@ -1,0 +1,145 @@
+# linkerd on Amazon ECS
+
+This example demonstrates deploying linkerd on an AWS ECS cluster, using Consul
+for service discovery.
+
+Full instructions can be found in the
+[Getting Started: Running in ECS](https://linkerd.io/getting-started/ecs/)
+Guide.
+
+## Initial Setup
+
+```bash
+KEY_PAIR=<MY KEY PAIR NAME>
+```
+
+## Security Group
+
+```bash
+GROUP_ID=$(aws ec2 create-security-group --group-name l5d-demo-sg --description "Linkerd Demo" | jq -r .GroupId)
+aws ec2 authorize-security-group-ingress --group-id $GROUP_ID \
+  --ip-permissions \
+  FromPort=22,IpProtocol=tcp,ToPort=22,IpRanges=[{CidrIp="0.0.0.0/0"}] \
+  FromPort=4140,IpProtocol=tcp,ToPort=4140,IpRanges=[{CidrIp="0.0.0.0/0"}] \
+  FromPort=9990,IpProtocol=tcp,ToPort=9990,IpRanges=[{CidrIp="0.0.0.0/0"}] \
+  FromPort=3000,IpProtocol=tcp,ToPort=3000,IpRanges=[{CidrIp="0.0.0.0/0"}] \
+  FromPort=8500,IpProtocol=tcp,ToPort=8500,IpRanges=[{CidrIp="0.0.0.0/0"}] \
+  IpProtocol=-1,UserIdGroupPairs=[{GroupId=$GROUP_ID}]
+```
+
+## `consul-server`
+
+```bash
+aws ec2 run-instances --image-id ami-7d664a1d \
+  --instance-type m4.xlarge \
+  --user-data file://consul-server-user-data.txt \
+  --placement AvailabilityZone=us-west-1a \
+  --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=l5d-demo-consul-server}]" \
+  --key-name $KEY_PAIR --security-group-ids $GROUP_ID
+```
+
+## ECS Cluster
+
+```bash
+aws ecs create-cluster --cluster-name l5d-demo
+```
+
+### Role Policy
+
+```bash
+aws iam put-role-policy --role-name ecsInstanceRole --policy-name l5dDemoPolicy --policy-document file://ecs-role-policy.json
+```
+
+### Register Task Definitions
+
+```bash
+aws ecs register-task-definition --cli-input-json file://linkerd-task-definition.json
+aws ecs register-task-definition --cli-input-json file://linkerd-viz-task-definition.json
+aws ecs register-task-definition --cli-input-json file://consul-agent-task-definition.json
+aws ecs register-task-definition --cli-input-json file://consul-registrator-task-definition.json
+aws ecs register-task-definition --cli-input-json file://hello-world-task-definition.json
+```
+
+### Create Launch Configuration
+
+```bash
+aws autoscaling create-launch-configuration \
+  --launch-configuration-name l5d-demo-lc \
+  --image-id ami-7d664a1d \
+  --instance-type m4.xlarge \
+  --user-data file://ecs-user-data.txt \
+  --iam-instance-profile ecsInstanceRole \
+  --security-groups $GROUP_ID \
+  --key-name $KEY_PAIR
+```
+
+### Create Auto Scaling Group
+
+```bash
+aws autoscaling create-auto-scaling-group \
+  --auto-scaling-group-name l5d-demo-asg \
+  --launch-configuration-name l5d-demo-lc \
+  --min-size 1 --max-size 3 --desired-capacity 2 \
+  --tags ResourceId=l5d-demo-asg,ResourceType=auto-scaling-group,Key=Name,Value=l5d-demo-ecs,PropagateAtLaunch=true \
+  --availability-zones us-west-1a
+```
+
+### Deploy `hello-world`
+
+```bash
+aws ecs run-task --cluster l5d-demo --task-definition hello-world --count 2
+```
+
+## Test everything worked
+
+```bash
+# Select an ECS node
+ECS_NODE=$( \
+  aws ec2 describe-instances \
+    --filters Name=instance-state-name,Values=running Name=tag:Name,Values=l5d-demo-ecs \
+    --query Reservations[*].Instances[0].PublicDnsName --output text \
+)
+
+# test routing via linkerd
+http_proxy=$ECS_NODE:4140 curl hello
+Hello (172.31.20.160) World (172.31.19.35)!!
+
+# view linkerd and Consul UIs (osx)
+open http://$ECS_NODE:9990
+open http://$ECS_NODE:8500
+```
+
+### linkerd-viz
+
+Put some load on our example app
+
+```bash
+while true; do http_proxy=$ECS_NODE:4140 curl -s -o /dev/null hello; done
+```
+
+Deploy linkerd-viz
+
+```bash
+aws ecs run-task --cluster l5d-demo --task-definition linkerd-viz --count 1
+
+# find the ECS node running linkerd-viz
+TASK_ID=$(aws ecs list-tasks --cluster l5d-demo --family linkerd-viz --desired-status RUNNING --query taskArns[0] --output text)
+CONTAINER_INSTANCE=$(aws ecs describe-tasks --cluster l5d-demo --tasks $TASK_ID --query tasks[0].containerInstanceArn --output text)
+INSTANCE_ID=$(aws ecs describe-container-instances --cluster l5d-demo --container-instances $CONTAINER_INSTANCE --query containerInstances[0].ec2InstanceId --output text)
+ECS_NODE=$(aws ec2 describe-instances --instance-ids $INSTANCE_ID --query Reservations[*].Instances[0].PublicDnsName --output text)
+
+# view linkerd-viz (osx)
+open http://$ECS_NODE:3000
+```
+
+## Credits
+
+This example setup is based on these excellent blog posts:
+
+  - https://kevinholditch.co.uk/2017/06/28/running-linkerd-in-a-docker-container-on-aws-ecs/
+  - https://blog.unif.io/deploying-consul-with-ecs-2c4ca7ab2981
+  - https://medium.com/attest-engineering/linkerd-a-service-mesh-for-aws-ecs-937f201f847a
+
+## TODO
+
+- rolling a new linkerd version

--- a/ecs/consul-agent-task-definition.json
+++ b/ecs/consul-agent-task-definition.json
@@ -1,0 +1,80 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "consul-agent",
+      "image": "docker.io/consul:0.8.5",
+      "command": [
+        "consul", "agent", "-ui",
+        "-config-file", "/etc/consul/consul-agent.json",
+        "-data-dir", "/consul/data"
+      ],
+      "memory": 128,
+      "portMappings": [
+        {
+          "hostPort": 8301,
+          "containerPort": 8301,
+          "protocol": "tcp"
+        },
+        {
+          "hostPort": 8301,
+          "containerPort": 8301,
+          "protocol": "udp"
+        },
+        {
+          "hostPort": 8400,
+          "containerPort": 8400,
+          "protocol": "tcp"
+        },
+        {
+          "hostPort": 8500,
+          "containerPort": 8500,
+          "protocol": "tcp"
+        },
+        {
+          "hostPort": 53,
+          "containerPort": 53,
+          "protocol": "udp"
+        }
+      ],
+      "essential": true,
+      "mountPoints": [
+        {
+          "containerPath": "/etc/consul",
+          "sourceVolume": "consul-config",
+          "readOnly": true
+        },
+        {
+          "containerPath": "/consul/data",
+          "sourceVolume": "consul-data",
+          "readOnly": false
+        },
+        {
+          "containerPath": "/var/run/docker.sock",
+          "sourceVolume": "consul-docker",
+          "readOnly": true
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "/opt/consul/config"
+      },
+      "name": "consul-config"
+    },
+    {
+      "host": {
+        "sourcePath": "/opt/consul/data"
+      },
+      "name": "consul-data"
+    },
+    {
+      "host": {
+        "sourcePath": "/var/run/docker.sock"
+      },
+      "name": "consul-docker"
+    }
+  ],
+  "family": "consul-agent"
+}

--- a/ecs/consul-registrator-task-definition.json
+++ b/ecs/consul-registrator-task-definition.json
@@ -1,0 +1,39 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "consul-registrator",
+      "image": "gliderlabs/registrator:v7",
+      "entryPoint": ["/bin/consul-registrator/start.sh"],
+      "memory": 128,
+      "essential": true,
+      "mountPoints": [
+        {
+          "containerPath": "/bin/consul-registrator",
+          "sourceVolume": "consul-registrator-bin",
+          "readOnly": true
+        },
+        {
+          "containerPath": "/tmp/docker.sock",
+          "sourceVolume": "consul-registrator-docker",
+          "readOnly": true
+        }
+      ]
+    }
+  ],
+  "networkMode": "host",
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "/opt/consul-registrator/bin"
+      },
+      "name": "consul-registrator-bin"
+    },
+    {
+      "host": {
+        "sourcePath": "/var/run/docker.sock"
+      },
+      "name": "consul-registrator-docker"
+    }
+  ],
+  "family": "consul-registrator"
+}

--- a/ecs/consul-server-user-data.txt
+++ b/ecs/consul-server-user-data.txt
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+usermod -a -G docker ec2-user
+
+# Retrieve IP of this instance from the AWS API
+
+EC2_INSTANCE_IP_ADDRESS=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+
+mkdir -p /opt/consul/data
+mkdir -p /opt/consul/config
+
+docker run --net=host -p 8300:8300 -p 8301:8301 -p 8301:8301/udp -p 8302:8302 \
+  -p 8302:8302/udp -p 8400:8400 -p 8500:8500 -p 53:53/udp \
+  -v /opt/consul/data:/consul/data -v /opt/consul/config:/consul/config \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -h $EC2_INSTANCE_ID --name consul-server -e CONSUL_ALLOW_PRIVILEGED_PORTS=1 \
+  -l service_name=consul-server consul:0.8.5 agent -server \
+  -bootstrap-expect 1 -advertise $EC2_INSTANCE_IP_ADDRESS -client 0.0.0.0 -ui

--- a/ecs/ecs-role-policy.json
+++ b/ecs/ecs-role-policy.json
@@ -1,0 +1,13 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:StartTask",
+        "ec2:DescribeInstances"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/ecs/ecs-user-data.txt
+++ b/ecs/ecs-user-data.txt
@@ -1,0 +1,145 @@
+Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+MIME-Version: 1.0
+
+--==BOUNDARY==
+Content-Type: text/text/x-shellscript; charset="us-ascii"
+
+#!/bin/bash
+
+#
+# This script generates config to be used by their respective Task Definitions:
+# 1. consul-registrator startup script
+# 2. Consul Agent config
+# 3. linkerd config
+
+# Specify the cluster that the container instance should register into
+cluster=l5d-demo
+
+# Write the cluster configuration variable to the ecs.config file
+# (add any other configuration variables here also)
+echo ECS_CLUSTER=$cluster >> /etc/ecs/ecs.config
+
+usermod -a -G docker ec2-user
+
+# Install the AWS CLI and the jq JSON parser
+yum install -y aws-cli jq
+
+# Gather metadata for linkerd and Consul Agent
+
+EC2_INSTANCE_IP_ADDRESS=$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)
+EC2_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
+
+#
+# Generate consul-registrator startup file
+#
+
+mkdir -p /opt/consul-registrator/bin
+
+cat << EOF > /opt/consul-registrator/bin/start.sh
+#!/bin/sh
+exec /bin/registrator -ip ${EC2_INSTANCE_IP_ADDRESS} -retry-attempts -1 consul://${EC2_INSTANCE_IP_ADDRESS}:8500
+EOF
+
+chmod a+x /opt/consul-registrator/bin/start.sh
+
+#
+# Generate Consul Agent config file
+#
+
+mkdir -p /opt/consul/data
+mkdir -p /opt/consul/config
+
+cat << EOF > /opt/consul/config/consul-agent.json
+{
+  "advertise_addr": "${EC2_INSTANCE_IP_ADDRESS}",
+  "client_addr": "0.0.0.0",
+  "node_name": "${EC2_INSTANCE_ID}",
+  "retry_join_ec2": {
+    "tag_key": "Name",
+    "tag_value": "l5d-demo-consul-server"
+  }
+}
+EOF
+
+#
+# Generate linkerd config file
+#
+
+# The linkerd ECS task definition is configured to mount this config file into
+# its own Docker environment.
+
+mkdir -p /etc/linkerd
+
+cat << EOF > /etc/linkerd/linkerd.yaml
+admin:
+  ip: 0.0.0.0
+  port: 9990
+
+namers:
+- kind: io.l5d.consul
+  host: ${EC2_INSTANCE_IP_ADDRESS}
+  port: 8500
+
+telemetry:
+- kind: io.l5d.prometheus
+- kind: io.l5d.recentRequests
+  sampleRate: 0.25
+
+usage:
+  orgId: linkerd-examples-ecs
+
+routers:
+- protocol: http
+  label: outgoing
+  servers:
+  - ip: 0.0.0.0
+    port: 4140
+  interpreter:
+    kind: default
+    transformers:
+    # tranform all outgoing requests to deliver to incoming linkerd port 4141
+    - kind: io.l5d.port
+      port: 4141
+  dtab: |
+    /svc => /#/io.l5d.consul/dc1;
+- protocol: http
+  label: incoming
+  servers:
+  - ip: 0.0.0.0
+    port: 4141
+  interpreter:
+    kind: default
+    transformers:
+    # filter instances to only include those on this host
+    - kind: io.l5d.specificHost
+      host: ${EC2_INSTANCE_IP_ADDRESS}
+  dtab: |
+    /svc => /#/io.l5d.consul/dc1;
+EOF
+
+--==BOUNDARY==
+Content-Type: text/text/upstart-job; charset="us-ascii"
+
+#upstart-job
+description "Amazon EC2 Container Service (start task on instance boot)"
+author "Amazon Web Services"
+start on started ecs
+
+script
+  exec 2>>/var/log/ecs/ecs-start-task.log
+  set -x
+
+  until curl -s http://localhost:51678/v1/metadata
+  do
+    sleep 1
+  done
+
+  instance_arn=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .ContainerInstanceArn' | awk -F/ '{print $NF}' )
+  cluster=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .Cluster' | awk -F/ '{print $NF}' )
+  region=$(curl -s http://localhost:51678/v1/metadata | jq -r '. | .ContainerInstanceArn' | awk -F: '{print $4}')
+
+  aws ecs start-task --cluster $cluster --task-definition consul-agent --container-instances $instance_arn --started-by $instance_arn --region $region
+  aws ecs start-task --cluster $cluster --task-definition consul-registrator --container-instances $instance_arn --started-by $instance_arn --region $region
+  aws ecs start-task --cluster $cluster --task-definition linkerd --container-instances $instance_arn --started-by $instance_arn --region $region
+end script
+--==BOUNDARY==--

--- a/ecs/hello-world-task-definition.json
+++ b/ecs/hello-world-task-definition.json
@@ -1,0 +1,49 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "hello",
+      "image": "docker.io/buoyantio/helloworld:0.1.4",
+      "entryPoint": ["/bin/sh", "-c"],
+      "command": [
+        "LOCAL_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4) http_proxy=$LOCAL_IP:4140 POD_IP=$LOCAL_IP helloworld -addr=:1234 -text=Hello -target=world"
+      ],
+      "environment": [
+        {
+          "name": "SERVICE_NAME",
+          "value": "hello"
+        }
+      ],
+      "memory": 128,
+      "portMappings": [
+        {
+          "containerPort": 1234,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true
+    },
+    {
+      "name": "world",
+      "image": "docker.io/buoyantio/helloworld:0.1.4",
+      "entryPoint": ["/bin/sh", "-c"],
+      "command": [
+        "LOCAL_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4) http_proxy=$LOCAL_IP:4140 POD_IP=$LOCAL_IP helloworld -addr=:1234 -text=World"
+      ],
+      "environment": [
+        {
+          "name": "SERVICE_NAME",
+          "value": "world"
+        }
+      ],
+      "memory": 128,
+      "portMappings": [
+        {
+          "containerPort": 1234,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true
+    }
+  ],
+  "family": "hello-world"
+}

--- a/ecs/hello-world-task-definition.json
+++ b/ecs/hello-world-task-definition.json
@@ -43,6 +43,28 @@
         }
       ],
       "essential": true
+    },
+    {
+      "name": "world-v2",
+      "image": "docker.io/buoyantio/helloworld:0.1.4",
+      "entryPoint": ["/bin/sh", "-c"],
+      "command": [
+        "LOCAL_IP=$(curl http://169.254.169.254/latest/meta-data/local-ipv4) http_proxy=$LOCAL_IP:4140 POD_IP=$LOCAL_IP helloworld -addr=:1234 -text=World-V2"
+      ],
+      "environment": [
+        {
+          "name": "SERVICE_NAME",
+          "value": "world-v2"
+        }
+      ],
+      "memory": 128,
+      "portMappings": [
+        {
+          "containerPort": 1234,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true
     }
   ],
   "family": "hello-world"

--- a/ecs/linkerd-task-definition.json
+++ b/ecs/linkerd-task-definition.json
@@ -1,0 +1,54 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "linkerd",
+      "image": "docker.io/buoyantio/linkerd:1.1.2",
+      "command": [
+        "-log.level=DEBUG",
+        "-com.twitter.finagle.tracing.debugTrace=true",
+        "/etc/linkerd/linkerd.yaml"
+      ],
+      "memory": 1024,
+      "portMappings": [
+        {
+          "hostPort": 4140,
+          "containerPort": 4140,
+          "protocol": "tcp"
+        },
+        {
+          "hostPort": 4141,
+          "containerPort": 4141,
+          "protocol": "tcp"
+        },
+        {
+          "hostPort": 9990,
+          "containerPort": 9990,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true,
+      "mountPoints": [
+        {
+          "containerPath": "/etc/linkerd",
+          "sourceVolume": "linkerd-config",
+          "readOnly": true
+        }
+      ],
+      "environment": [
+        {
+          "name": "SERVICE_9990_NAME",
+          "value": "linkerd"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "host": {
+        "sourcePath": "/etc/linkerd"
+      },
+      "name": "linkerd-config"
+    }
+  ],
+  "family": "linkerd"
+}

--- a/ecs/linkerd-viz-task-definition.json
+++ b/ecs/linkerd-viz-task-definition.json
@@ -1,0 +1,27 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "linkerd-viz",
+      "image": "docker.io/buoyantio/linkerd-viz:0.1.3",
+      "command": [
+        "consul"
+      ],
+      "memory": 1024,
+      "portMappings": [
+        {
+          "hostPort": 3000,
+          "containerPort": 3000,
+          "protocol": "tcp"
+        },
+        {
+          "hostPort": 9191,
+          "containerPort": 9191,
+          "protocol": "tcp"
+        }
+      ],
+      "essential": true
+    }
+  ],
+  "family": "linkerd-viz",
+  "networkMode": "host"
+}

--- a/ecs/linkerd-viz-task-definition.json
+++ b/ecs/linkerd-viz-task-definition.json
@@ -19,7 +19,13 @@
           "protocol": "tcp"
         }
       ],
-      "essential": true
+      "essential": true,
+      "environment": [
+        {
+          "name": "SCRAPE_INTERVAL",
+          "value": "5s"
+        }
+      ]
     }
   ],
   "family": "linkerd-viz",


### PR DESCRIPTION
This demonstrates setting up an ECS Cluster with linkerd for routing and
Consul for service discovery.