### PR TITLE
Add example of grpc istio running in minikube

### DIFF
--- a/istio/helloworld-grpc-minikube/README.md
+++ b/istio/helloworld-grpc-minikube/README.md
@@ -1,0 +1,23 @@
+# Hello World example
+
+Example app for istio-linkerd in minikube using grpc.
+Assumes you've gone through the first four steps of the
+[Istio installation guide](https://istio.io/docs/tasks/installing-istio.html).
+
+```
+# Deploy istio-pilot, istio-mixer and egress
+kubectl apply -f ../mixer-pilot.yml -f ../istio-egress.yml
+
+# Add Ingress Resource
+kubectl apply -f hello-ingress.yml
+
+# Add grpc-specific linkerds
+kubectl apply -f istio-daemonset.yml -f istio-ingress.yml
+
+# Use linkerd-inject to modify the hello world grpc config, and deploy it:
+kubectl apply -f <(linkerd-inject -useServiceVip -f hello-world.yml)
+
+# Verify deployment
+LB=$(minikube ip):$(kubectl get svc istio-ingress -o jsonpath="{.spec.ports[0].nodePort}")
+helloworld-client $LB
+```

--- a/istio/helloworld-grpc-minikube/README.md
+++ b/istio/helloworld-grpc-minikube/README.md
@@ -15,7 +15,7 @@ kubectl apply -f hello-ingress.yml
 kubectl apply -f istio-daemonset.yml -f istio-ingress.yml
 
 # Use linkerd-inject to modify the hello world grpc config, and deploy it:
-kubectl apply -f <(linkerd-inject -useServiceVip -f hello-world.yml)
+kubectl apply -f <(linkerd-inject -useServiceVip -f hello-world-grpc.yml)
 
 # Verify deployment
 LB=$(minikube ip):$(kubectl get svc istio-ingress -o jsonpath="{.spec.ports[0].nodePort}")

--- a/istio/helloworld-grpc-minikube/hello-ingress.yml
+++ b/istio/helloworld-grpc-minikube/hello-ingress.yml
@@ -1,0 +1,13 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: hello-ingress
+  annotations:
+    kubernetes.io/ingress.class: "istio"
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: hello
+          servicePort: http

--- a/istio/helloworld-grpc-minikube/hello-world-grpc.yml
+++ b/istio/helloworld-grpc-minikube/hello-world-grpc.yml
@@ -1,0 +1,82 @@
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: hello
+spec:
+  selector:
+    app: hello
+  template:
+    metadata:
+      labels:
+        app: hello
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: service
+        image: buoyantio/helloworld:0.1.4
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        args:
+        - "-addr=:7777"
+        - "-text=Hello"
+        - "-target=world:7778"
+        - "-protocol=grpc"
+        ports:
+        - name: service
+          containerPort: 7777
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hello
+spec:
+  selector:
+    app: hello
+  ports:
+  - name: http
+    port: 7777
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: world-v1
+spec:
+  selector:
+    app: world-v1
+  template:
+    metadata:
+      labels:
+        app: world-v1
+    spec:
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: service
+        image: buoyantio/helloworld:0.1.4
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: TARGET_WORLD
+          value: world
+        args:
+        - "-addr=:7778"
+        - "-protocol=grpc"
+        ports:
+        - name: service
+          containerPort: 7778
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: world
+spec:
+  selector:
+    app: world-v1
+  ports:
+  - name: http
+    port: 7778

--- a/istio/helloworld-grpc-minikube/istio-daemonset.yml
+++ b/istio/helloworld-grpc-minikube/istio-daemonset.yml
@@ -1,0 +1,120 @@
+---
+################################
+# Linkerd Daemonset
+################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: l5d-config
+data:
+  config.yaml: |-
+    admin:
+      port: 9990
+
+    telemetry:
+    - kind: io.l5d.prometheus
+    - kind: io.l5d.recentRequests
+      sampleRate: 0.25
+
+    routers:
+    - protocol: h2
+      experimental: true
+      label: outgoing
+      identifier:
+        kind: io.l5d.k8s.istio
+      interpreter:
+        kind: io.l5d.k8s.istio
+        experimental: true
+        transformers:
+        - kind: io.l5d.k8s.daemonset
+          namespace: default
+          port: incoming
+          service: l5d
+      servers:
+      - port: 4140
+        ip: 0.0.0.0
+      loggers:
+        - kind: io.l5d.k8s.istio
+      service:
+        responseClassifier:
+          kind: io.l5d.http.retryableRead5XX
+
+    - protocol: h2
+      experimental: true
+      label: incoming
+      identifier:
+        kind: io.l5d.k8s.istio
+      interpreter:
+        kind: io.l5d.k8s.istio
+        experimental: true
+        transformers:
+        - kind: io.l5d.k8s.localnode
+      servers:
+      - port: 4141
+        ip: 0.0.0.0
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: l5d
+  name: l5d
+spec:
+  template:
+    metadata:
+      labels:
+        app: l5d
+    spec:
+      volumes:
+      - name: l5d-config
+        configMap:
+          name: "l5d-config"
+      containers:
+      - name: l5d
+        image: buoyantio/linkerd:1.1.2-SNAPSHOT
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        args:
+        - /io.buoyant/linkerd/config/config.yaml
+        ports:
+        - name: outgoing
+          containerPort: 4140
+          hostPort: 4140
+        - name: incoming
+          containerPort: 4141
+        - name: admin
+          containerPort: 9990
+        volumeMounts:
+        - name: "l5d-config"
+          mountPath: "/io.buoyant/linkerd/config"
+          readOnly: true
+
+      - name: kubectl
+        image: buoyantio/kubectl:v1.4.0
+        args:
+        - "proxy"
+        - "-p"
+        - "8001"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: l5d
+spec:
+  selector:
+    app: l5d
+  type: LoadBalancer
+  ports:
+  - name: outgoing
+    port: 4140
+  - name: incoming
+    port: 4141
+  - name: admin
+    port: 9990

--- a/istio/helloworld-grpc-minikube/istio-ingress.yml
+++ b/istio/helloworld-grpc-minikube/istio-ingress.yml
@@ -1,0 +1,90 @@
+---
+################################
+# Istio ingress controller
+################################
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-ingress-config
+data:
+  config.yaml: |-
+    telemetry:
+    - kind: io.l5d.prometheus
+    - kind: io.l5d.recentRequests
+      sampleRate: 0.25
+
+    routers:
+    - protocol: h2
+      experimental: true
+      identifier:
+        kind: io.l5d.k8s.istio-ingress
+      interpreter:
+        kind: io.l5d.k8s.istio
+        experimental: true
+      loggers:
+        - kind: io.l5d.k8s.istio
+      servers:
+        - port: 80
+          ip: 0.0.0.0
+          clearContext: true
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: istio-ingress
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: ignore
+      labels:
+        istio: ingress
+    spec:
+      serviceAccountName: istio-ingress-service-account
+      volumes:
+      - name: istio-ingress-config
+        configMap:
+          name: "istio-ingress-config"
+      containers:
+      - name: l5d
+        image: buoyantio/linkerd:1.1.2-SNAPSHOT
+        env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        args:
+        - /io.buoyant/linkerd/config/config.yaml
+        ports:
+        - name: http
+          containerPort: 80
+        - name: admin
+          containerPort: 9990
+        volumeMounts:
+        - name: "istio-ingress-config"
+          mountPath: "/io.buoyant/linkerd/config"
+          readOnly: true
+
+      - name: kubectl
+        image: buoyantio/kubectl:v1.6.2
+        args: ["proxy", "-p", "8001"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: istio-ingress
+spec:
+  selector:
+    istio: ingress
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+  - name: admin
+    port: 9990
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-ingress-service-account


### PR DESCRIPTION
This folder includes k8s configs that are grpc-specific, but also uses some configs from the top level istio directory that didn't need changes. Looking at this more, maybe we should combine the http & h2 into 1 set of example configs. 

Requires https://github.com/linkerd/linkerd/pull/1528