### PR TITLE
Don't use hostPort for ingress

### DIFF
--- a/k8s-daemonset/k8s/linkerd-ingress-controller.yml
+++ b/k8s-daemonset/k8s/linkerd-ingress-controller.yml
@@ -50,7 +50,6 @@ spec:
         ports:
         - name: http
           containerPort: 80
-          hostPort: 80
         - name: admin
           containerPort: 9990
         volumeMounts:


### PR DESCRIPTION
We already have a LoadBalancer service defined, so this isn't strictly necessary