### PR TITLE
Rename linkerdtcp and linkerd_viz containers in demo

### DIFF
--- a/linkerd-tcp/docker-compose.yml
+++ b/linkerd-tcp/docker-compose.yml
@@ -5,61 +5,61 @@ services:
     build: .
     command:
     - "-addr=:7770"
-    - "-redis-addr=linkerdtcp:7474"
+    - "-redis-addr=linkerd-tcp:7474"
 
   web1:
     build: .
     command:
     - "-addr=:7771"
-    - "-redis-addr=linkerdtcp:7474"
+    - "-redis-addr=linkerd-tcp:7474"
 
   web2:
     build: .
     command:
     - "-addr=:7772"
-    - "-redis-addr=linkerdtcp:7474"
+    - "-redis-addr=linkerd-tcp:7474"
 
   web3:
     build: .
     command:
     - "-addr=:7773"
-    - "-redis-addr=linkerdtcp:7474"
+    - "-redis-addr=linkerd-tcp:7474"
 
   web4:
     build: .
     command:
     - "-addr=:7774"
-    - "-redis-addr=linkerdtcp:7474"
+    - "-redis-addr=linkerd-tcp:7474"
 
   web5:
     build: .
     command:
     - "-addr=:7775"
-    - "-redis-addr=linkerdtcp:7474"
+    - "-redis-addr=linkerd-tcp:7474"
 
   web6:
     build: .
     command:
     - "-addr=:7776"
-    - "-redis-addr=linkerdtcp:7474"
+    - "-redis-addr=linkerd-tcp:7474"
 
   web7:
     build: .
     command:
     - "-addr=:7777"
-    - "-redis-addr=linkerdtcp:7474"
+    - "-redis-addr=linkerd-tcp:7474"
 
   web8:
     build: .
     command:
     - "-addr=:7778"
-    - "-redis-addr=linkerdtcp:7474"
+    - "-redis-addr=linkerd-tcp:7474"
 
   web9:
     build: .
     command:
     - "-addr=:7779"
-    - "-redis-addr=linkerdtcp:7474"
+    - "-redis-addr=linkerd-tcp:7474"
 
   linkerd:
     image: buoyantio/linkerd:1.1.3
@@ -82,7 +82,7 @@ services:
     command:
     - "/io.buoyant/namerd/config.yml"
 
-  linkerdtcp:
+  linkerd-tcp:
     image: linkerd/linkerd-tcp:0.0.3
     ports:
     - 9992:9992
@@ -107,7 +107,7 @@ services:
     command:
     - "-redis.addr=redis://redis2:6379"
 
-  linkerd_viz:
+  linkerd-viz:
     image: buoyantio/linkerd-viz:0.1.4
     environment:
     - SCRAPE_INTERVAL=5s

--- a/linkerd-tcp/prometheus.yml
+++ b/linkerd-tcp/prometheus.yml
@@ -26,10 +26,10 @@ scrape_configs:
     regex:         .*\/([^/]+)
     replacement:   $1
 
-- job_name: 'linkerd_tcp'
+- job_name: 'linkerd-tcp'
   static_configs:
   - targets:
-    - 'linkerdtcp:9992'
+    - 'linkerd-tcp:9992'
 
 - job_name: 'redis1'
   static_configs:


### PR DESCRIPTION
In our linkerd-tcp demo, the container names `linkerdtcp` and `linkerd_viz` don't match the docker image names, which are `linkerd/linkerd-tcp` and `buoyantio/linkerd-viz`. It's also the case the `linkerd_viz` is not a valid domain name due to the underscore. For clarity, let's rename to `linkerd-tcp` and `linkerd-viz`.