### PR TITLE
Add ClusterFirstWithHostNet DNS policy to linkerd-cni

### DIFF
--- a/k8s-daemonset/k8s/linkerd-cni-legacy.yml
+++ b/k8s-daemonset/k8s/linkerd-cni-legacy.yml
@@ -1,8 +1,8 @@
 # runs linkerd in a daemonset, in linker-to-linker mode
 # for CNI setups such as Calico and Weave.
 #
-# this configuration does not support Kubernetes versions
-# earlier than 1.6, use `linkerd-cni-legacy.yml` instead.
+# legacy config for Kubernetes < 1.6 --- Zipkin telemetry
+# is not supported with this configuration.
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/k8s-daemonset/k8s/linkerd-cni.yml
+++ b/k8s-daemonset/k8s/linkerd-cni.yml
@@ -79,6 +79,7 @@ spec:
         app: l5d
     spec:
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
       - name: l5d-config
         configMap:


### PR DESCRIPTION
In order to support Zipkin telemetry in CNI deployments of Linkerd, we have to request `dnsPolicy: ClusterFirstWithHostNet`. Otherwise due to `hostNetwork: true` Pod specifier (for CNI deployment) the `dnsPolicy: default` is applied so that "cluster" addresses (`....svc.cluster.local`) are not resolved because `default` dns policy is to use node's host /etc/resolv.conf which may or may not (as it is in my case) refer to kube-dns for name resolution, at least this kind (the latter) of resolv.conf setup is done by kubeadm.

I've split the `linkerd-cni.yml` config file into separate `linkerd-cni.yml` and `linkerd-cni-legacy.yml`, since this DNS policy is not supported in versions of Kubernetes prior to 1.6. I've added comments noting that the legacy config should be used on earlier Kubernetes versions, and that Zipkin telemetry will not be supported with that config.

Fixes #161 