### PR TITLE
Update for linkerd 1.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: buoyantio/linkerd:1.1.3
+      - image: buoyantio/linkerd:1.2.0
         parallelism: 1 # TODO: parallelize tests
     working_directory: ~/linkerd-examples
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Contains sample code for building linkerd plugins. More information:
 ## Testing
 
 ```bash
-docker run -v `pwd`:/root/linkerd-examples --entrypoint=/root/linkerd-examples/.circleci/ci.sh buoyantio/linkerd:1.1.3
+docker run -v `pwd`:/root/linkerd-examples --entrypoint=/root/linkerd-examples/.circleci/ci.sh buoyantio/linkerd:1.2.0
 ```
 
 <!-- references -->

--- a/add-steps/docker-compose.yml
+++ b/add-steps/docker-compose.yml
@@ -121,7 +121,7 @@ services:
     command: -latency=2s -success-rate=0.4
 
   linkerd:
-    image: buoyantio/linkerd:1.1.3
+    image: buoyantio/linkerd:1.2.0
     ports:
       - 4140:4140
       - 9990:9990

--- a/add-steps/linkerd.yml
+++ b/add-steps/linkerd.yml
@@ -1,3 +1,7 @@
+admin:
+  ip: 0.0.0.0
+  port: 9990
+
 # use the filesystem namer, read from the local /disco directory
 namers:
 - kind: io.l5d.fs

--- a/consul/docker-compose.yml
+++ b/consul/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "7777:7777"
 
   linkerd:
-    image: buoyantio/linkerd:1.1.3
+    image: buoyantio/linkerd:1.2.0
     command: ['/config.yaml']
     links:
       - consul

--- a/consul/linkerd.yml
+++ b/consul/linkerd.yml
@@ -1,8 +1,13 @@
+admin:
+  ip: 0.0.0.0
+  port: 9990
+
 namers:
 - kind: io.l5d.consul
   includeTag: false
   useHealthCheck: false
   host: consul
+
 routers:
 - protocol: http
   label: /http-consul

--- a/dcos/ingress/linkerd-config.yml
+++ b/dcos/ingress/linkerd-config.yml
@@ -3,6 +3,7 @@
 # port 4242 automatically routes to "webapp"
 
 admin:
+  ip: 0.0.0.0
   port: 9990
 
 telemetry:

--- a/dcos/ingress/linkerd-dcos.json
+++ b/dcos/ingress/linkerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.1.3",
+      "image": "buoyantio/linkerd:1.2.0",
       "network": "HOST",
       "privileged": true
     }
@@ -38,5 +38,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4242,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/svc/*=>/#/io.l5d.marathon/webapp;\\\",\\\"label\\\":\\\"external\\\"}]}\" | /io.buoyant/linkerd/1.1.3/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4242,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/svc/*=>/#/io.l5d.marathon/webapp;\\\",\\\"label\\\":\\\"external\\\"}]}\" | /io.buoyant/linkerd/1.2.0/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
 }

--- a/dcos/linker-to-linker-with-namerd/linkerd-config.yml
+++ b/dcos/linker-to-linker-with-namerd/linkerd-config.yml
@@ -3,6 +3,7 @@
 # all service discovery managed via namerd
 
 admin:
+  ip: 0.0.0.0
   port: 9990
 
 telemetry:

--- a/dcos/linker-to-linker-with-namerd/linkerd-dcos.json
+++ b/dcos/linker-to-linker-with-namerd/linkerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.1.3",
+      "image": "buoyantio/linkerd:1.2.0",
       "network": "HOST",
       "privileged": true
     }
@@ -38,5 +38,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"outgoing\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.mesos/4100\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.port\\\",\\\"port\\\":4141}]}},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4141,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"incoming\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.mesos/4100\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.localhost\\\"}]}}]}\" | /io.buoyant/linkerd/1.1.3/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"outgoing\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.mesos/4100\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.port\\\",\\\"port\\\":4141}]}},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4141,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"incoming\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.mesos/4100\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.localhost\\\"}]}}]}\" | /io.buoyant/linkerd/1.2.0/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
 }

--- a/dcos/linker-to-linker/linkerd-config.yml
+++ b/dcos/linker-to-linker/linkerd-config.yml
@@ -2,6 +2,7 @@
 # routes from port 4140 on source node to 4141 on destination node
 
 admin:
+  ip: 0.0.0.0
   port: 9990
 
 telemetry:

--- a/dcos/linker-to-linker/linkerd-dcos.json
+++ b/dcos/linker-to-linker/linkerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.1.3",
+      "image": "buoyantio/linkerd:1.2.0",
       "network": "HOST",
       "privileged": true
     }
@@ -38,5 +38,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"outgoing\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"default\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.port\\\",\\\"port\\\":4141}]}},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4141,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"incoming\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"default\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.localhost\\\"}]}}]}\" | /io.buoyant/linkerd/1.1.3/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"outgoing\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"default\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.port\\\",\\\"port\\\":4141}]}},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4141,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"incoming\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"default\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.localhost\\\"}]}}]}\" | /io.buoyant/linkerd/1.2.0/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
 }

--- a/dcos/linkerd-marathon-auth/linkerd-config.yml
+++ b/dcos/linkerd-marathon-auth/linkerd-config.yml
@@ -3,6 +3,7 @@
 # configured to connect to DC/OS in Strict mode, via Marathon TLS
 
 admin:
+  ip: 0.0.0.0
   port: 9990
 
 telemetry:

--- a/dcos/linkerd-marathon-auth/linkerd-dcos.json
+++ b/dcos/linkerd-marathon-auth/linkerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.1.3",
+      "image": "buoyantio/linkerd:1.2.0",
       "network": "HOST",
       "privileged": true
     }
@@ -41,5 +41,5 @@
     }
   },
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"leader.mesos\\\",\\\"port\\\":443,\\\"prefix\\\":\\\"/io.l5d.marathon\\\",\\\"uriPrefix\\\":\\\"/marathon\\\",\\\"tls\\\":{\\\"disableValidation\\\":false,\\\"commonName\\\":\\\"master.mesos\\\",\\\"trustCerts\\\":[\\\"/mnt/mesos/sandbox/.ssl/ca.crt\\\"]}}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.1.3/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"leader.mesos\\\",\\\"port\\\":443,\\\"prefix\\\":\\\"/io.l5d.marathon\\\",\\\"uriPrefix\\\":\\\"/marathon\\\",\\\"tls\\\":{\\\"disableValidation\\\":false,\\\"commonName\\\":\\\"master.mesos\\\",\\\"trustCerts\\\":[\\\"/mnt/mesos/sandbox/.ssl/ca.crt\\\"]}}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.2.0/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
 }

--- a/dcos/linkerd-with-namerd/linkerd-config.yml
+++ b/dcos/linkerd-with-namerd/linkerd-config.yml
@@ -3,6 +3,7 @@
 # all service discovery managed via namerd
 
 admin:
+  ip: 0.0.0.0
   port: 9990
 
 telemetry:

--- a/dcos/linkerd-with-namerd/linkerd-dcos.json
+++ b/dcos/linkerd-with-namerd/linkerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.1.3",
+      "image": "buoyantio/linkerd:1.2.0",
       "network": "HOST",
       "privileged": true
     }
@@ -33,5 +33,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"linkerd_proxy\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.mesos/4100\\\"}}]}\" | /io.buoyant/linkerd/1.1.3/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"linkerd_proxy\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.mesos/4100\\\"}}]}\" | /io.buoyant/linkerd/1.2.0/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
 }

--- a/dcos/namerd/namerd-config.yml
+++ b/dcos/namerd/namerd-config.yml
@@ -3,7 +3,8 @@
 # thrift interface (for linkerd) on port 4100
 
 admin:
-  port: 9001
+  ip: 0.0.0.0
+  port: 9991
 
 storage:
   kind: io.l5d.zk

--- a/dcos/namerd/namerd-dcos.json
+++ b/dcos/namerd/namerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/namerd:1.1.3-dcos",
+      "image": "buoyantio/namerd:1.2.0-dcos",
       "network": "HOST",
       "privileged": true
     }
@@ -22,7 +22,7 @@
   ],
   "portDefinitions": [
     {
-      "port": 9001,
+      "port": 9991,
       "protocol": "tcp",
       "name": "admin"
     },
@@ -38,5 +38,5 @@
     }
   ],
   "requirePorts":true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"port\\\":9001},\\\"storage\\\":{\\\"kind\\\":\\\"io.l5d.zk\\\",\\\"zkAddrs\\\":[{\\\"host\\\":\\\"leader.mesos\\\",\\\"port\\\":2181}],\\\"pathPrefix\\\":\\\"/dtabs\\\",\\\"sessionTimeoutMs\\\":10000},\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"interfaces\\\":[{\\\"kind\\\":\\\"io.l5d.thriftNameInterpreter\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4100},{\\\"kind\\\":\\\"io.l5d.httpController\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4180}]}\" | /io.buoyant/namerd/1.1.3/dcos-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9991},\\\"storage\\\":{\\\"kind\\\":\\\"io.l5d.zk\\\",\\\"zkAddrs\\\":[{\\\"host\\\":\\\"leader.mesos\\\",\\\"port\\\":2181}],\\\"pathPrefix\\\":\\\"/dtabs\\\",\\\"sessionTimeoutMs\\\":10000},\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"interfaces\\\":[{\\\"kind\\\":\\\"io.l5d.thriftNameInterpreter\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4100},{\\\"kind\\\":\\\"io.l5d.httpController\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4180}]}\" | /io.buoyant/namerd/1.2.0/dcos-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
 }

--- a/dcos/simple-proxy/linkerd-config.yml
+++ b/dcos/simple-proxy/linkerd-config.yml
@@ -2,6 +2,7 @@
 # listens on port 4140, routes via http_proxy or host header
 
 admin:
+  ip: 0.0.0.0
   port: 9990
 
 telemetry:

--- a/dcos/simple-proxy/linkerd-dcos.json
+++ b/dcos/simple-proxy/linkerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.1.3",
+      "image": "buoyantio/linkerd:1.2.0",
       "network": "HOST",
       "privileged": true
     }
@@ -33,5 +33,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.1.3/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.2.0/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
 }

--- a/ecs/linkerd-task-definition.json
+++ b/ecs/linkerd-task-definition.json
@@ -2,7 +2,7 @@
   "containerDefinitions": [
     {
       "name": "linkerd",
-      "image": "docker.io/buoyantio/linkerd:1.1.3",
+      "image": "docker.io/buoyantio/linkerd:1.2.0",
       "command": [
         "-log.level=DEBUG",
         "-com.twitter.finagle.tracing.debugTrace=true",

--- a/failure-accrual/docker-compose.yml
+++ b/failure-accrual/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     build: .
 
   linkerd:
-    image: buoyantio/linkerd:1.1.3
+    image: buoyantio/linkerd:1.2.0
     ports:
       - 9990:9990
     volumes:

--- a/failure-accrual/linkerd.yml
+++ b/failure-accrual/linkerd.yml
@@ -1,3 +1,7 @@
+admin:
+  ip: 0.0.0.0
+  port: 9990
+
 namers:
 - kind: io.l5d.fs
   rootDir: /disco

--- a/getting-started/docker/docker-compose.yml
+++ b/getting-started/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   # linkerd
   l5d:
-    image: buoyantio/linkerd:1.1.3
+    image: buoyantio/linkerd:1.2.0
     ports:
     - "4140:4140"
     - "9990:9990"

--- a/getting-started/docker/linkerd.yaml
+++ b/getting-started/docker/linkerd.yaml
@@ -1,3 +1,7 @@
+admin:
+  ip: 0.0.0.0
+  port: 9990
+
 # The filesystem namer (io.l5d.fs) watches the disco directory for changes.
 # Each file in this directory represents a concrete name and contains a list
 # of hostname/port pairs.

--- a/getting-started/k8s/linkerd.yml
+++ b/getting-started/k8s/linkerd.yml
@@ -7,6 +7,10 @@ data:
   config.yml: |-
     # The Kubernetes namer (io.l5d.k8s) queries the Kubernetes master API
     # for a list of pods with a given name.
+    admin:
+      ip: 0.0.0.0
+      port: 9990
+
     namers:
     - kind: io.l5d.k8s
       experimental: true
@@ -42,7 +46,7 @@ spec:
     spec:
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         args:
         - "/io.buoyant/linkerd/config/config.yml"
         ports:

--- a/getting-started/local/linkerd.yaml
+++ b/getting-started/local/linkerd.yaml
@@ -1,3 +1,7 @@
+admin:
+  ip: 0.0.0.0
+  port: 9990
+
 # The filesystem namer (io.l5d.fs) watches the disco directory for changes.
 # Each file in this directory represents a concrete name and contains a list
 # of hostname/port pairs.

--- a/gob/dcos/linkerd-dcos-gob.yaml
+++ b/gob/dcos/linkerd-dcos-gob.yaml
@@ -1,3 +1,7 @@
+admin:
+  ip: 0.0.0.0
+  port: 9990
+
 routers:
 - protocol: http
   interpreter:

--- a/gob/dcos/marathon/linkerd.json
+++ b/gob/dcos/marathon/linkerd.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.1.3",
+      "image": "buoyantio/linkerd:1.2.0",
       "network": "HOST",
       "privileged": true
     }
@@ -38,5 +38,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.slave.mesos/4100\\\"},\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}]},{\\\"protocol\\\":\\\"h2\\\",\\\"experimental\\\":true,\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.slave.mesos/4100\\\"},\\\"servers\\\":[{\\\"port\\\":4142,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dstPrefix\\\":\\\"/grpc\\\",\\\"identifier\\\":{\\\"kind\\\":\\\"io.l5d.header.path\\\"}}]}\" | /io.buoyant/linkerd/1.1.3/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.slave.mesos/4100\\\"},\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}]},{\\\"protocol\\\":\\\"h2\\\",\\\"experimental\\\":true,\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.slave.mesos/4100\\\"},\\\"servers\\\":[{\\\"port\\\":4142,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dstPrefix\\\":\\\"/grpc\\\",\\\"identifier\\\":{\\\"kind\\\":\\\"io.l5d.header.path\\\"}}]}\" | /io.buoyant/linkerd/1.2.0/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
 }

--- a/gob/dcos/marathon/namerd.json
+++ b/gob/dcos/marathon/namerd.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/namerd:1.1.3-dcos",
+      "image": "buoyantio/namerd:1.2.0-dcos",
       "network": "HOST",
       "privileged": true
     }
@@ -22,7 +22,7 @@
   ],
   "portDefinitions": [
     {
-      "port": 9001,
+      "port": 9991,
       "protocol": "tcp",
       "name": "admin"
     },
@@ -38,5 +38,5 @@
     }
   ],
   "requirePorts":true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"port\\\":9001},\\\"storage\\\":{\\\"kind\\\":\\\"io.l5d.zk\\\",\\\"experimental\\\":true,\\\"zkAddrs\\\":[{\\\"host\\\":\\\"master.mesos\\\",\\\"port\\\":2181}],\\\"pathPrefix\\\":\\\"/dtabs\\\",\\\"sessionTimeoutMs\\\":10000},\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"experimental\\\":true,\\\"prefix\\\":\\\"/io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"interfaces\\\":[{\\\"kind\\\":\\\"io.l5d.thriftNameInterpreter\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4100},{\\\"kind\\\":\\\"io.l5d.httpController\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4180}]}\" | /io.buoyant/namerd/1.1.3/dcos-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9991},\\\"storage\\\":{\\\"kind\\\":\\\"io.l5d.zk\\\",\\\"experimental\\\":true,\\\"zkAddrs\\\":[{\\\"host\\\":\\\"master.mesos\\\",\\\"port\\\":2181}],\\\"pathPrefix\\\":\\\"/dtabs\\\",\\\"sessionTimeoutMs\\\":10000},\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"experimental\\\":true,\\\"prefix\\\":\\\"/io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"interfaces\\\":[{\\\"kind\\\":\\\"io.l5d.thriftNameInterpreter\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4100},{\\\"kind\\\":\\\"io.l5d.httpController\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4180}]}\" | /io.buoyant/namerd/1.2.0/dcos-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
 }

--- a/gob/dcos/namerd-dcos-gob.yaml
+++ b/gob/dcos/namerd-dcos-gob.yaml
@@ -1,5 +1,6 @@
 admin:
-  port: 9001
+  ip: 0.0.0.0
+  port: 9991
 storage:
   kind: io.l5d.zk
   experimental: true

--- a/gob/docker-compose.yml
+++ b/gob/docker-compose.yml
@@ -20,14 +20,14 @@ services:
     command: word
 
   linkerd:
-    image: buoyantio/linkerd:1.1.3
+    image: buoyantio/linkerd:1.2.0
     container_name: linkerd
     ports: ["4142:4142", "4141:4141", "9990:9990"]
     volumes: ["./config:/io.buoyant/linkerd/config:ro"]
     command: /io.buoyant/linkerd/config/linkerd.yml
 
   namerd:
-    image: buoyantio/namerd:1.1.3
+    image: buoyantio/namerd:1.2.0
     container_name: namerd
     ports: ["4100:4100", "4180:4180", "9991:9991"]
     volumes: ["./config:/io.buoyant/linkerd/config:ro"]

--- a/gob/k8s/gen-growthhack/rc.yml
+++ b/gob/k8s/gen-growthhack/rc.yml
@@ -32,7 +32,7 @@ spec:
               containerPort: 8080
 
         - name: l5d
-          image: buoyantio/linkerd:1.1.3
+          image: buoyantio/linkerd:1.2.0
           args:
             - "/io.buoyant/linkerd/config/config.yml"
 

--- a/gob/k8s/gen/rc.yml
+++ b/gob/k8s/gen/rc.yml
@@ -32,7 +32,7 @@ spec:
               containerPort: 8080
 
         - name: l5d
-          image: buoyantio/linkerd:1.1.3
+          image: buoyantio/linkerd:1.2.0
           args:
             - "/io.buoyant/linkerd/config/config.yml"
 

--- a/gob/k8s/linkerd.yml
+++ b/gob/k8s/linkerd.yml
@@ -5,6 +5,10 @@ metadata:
   namespace: default
 data:
   config.yml: |-
+    admin:
+      ip: 0.0.0.0
+      port: 9990
+
     routers:
     - protocol: http
       servers:

--- a/gob/k8s/namerd/rc.yml
+++ b/gob/k8s/namerd/rc.yml
@@ -21,7 +21,7 @@ spec:
 
       containers:
         - name: namerd
-          image: buoyantio/namerd:1.1.3
+          image: buoyantio/namerd:1.2.0
           args:
             - /io.buoyant/namerd/config/config.yml
           imagePullPolicy: Always

--- a/gob/k8s/web/rc.yml
+++ b/gob/k8s/web/rc.yml
@@ -34,7 +34,7 @@ spec:
               containerPort: 8080
 
         - name: l5d
-          image: buoyantio/linkerd:1.1.3
+          image: buoyantio/linkerd:1.2.0
           args:
             - /io.buoyant/linkerd/config/config.yml
 

--- a/gob/k8s/word/rc.yml
+++ b/gob/k8s/word/rc.yml
@@ -32,7 +32,7 @@ spec:
               containerPort: 8080
 
         - name: l5d
-          image: buoyantio/linkerd:1.1.3
+          image: buoyantio/linkerd:1.2.0
           args:
             - "/io.buoyant/linkerd/config/config.yml"
 

--- a/http-proxy/README.md
+++ b/http-proxy/README.md
@@ -12,9 +12,9 @@ echo "Hello world" > hello; python3 -m http.server 8888
 ## Setup linkerd
 
 ```bash
-curl -sLO https://github.com/linkerd/linkerd/releases/download/1.1.3/linkerd-1.1.3-exec
-chmod +x linkerd-1.1.3-exec
-./linkerd-1.1.3-exec ./linkerd.yaml
+curl -sLO https://github.com/linkerd/linkerd/releases/download/1.2.0/linkerd-1.2.0-exec
+chmod +x linkerd-1.2.0-exec
+./linkerd-1.2.0-exec ./linkerd.yaml
 ```
 
 ## Test

--- a/http-proxy/linkerd.yaml
+++ b/http-proxy/linkerd.yaml
@@ -1,3 +1,7 @@
+admin:
+  ip: 0.0.0.0
+  port: 9990
+
 routers:
 - protocol: http
   dtab: /svc/webapp => /$/inet/127.1/8888

--- a/influxdb/docker-compose.yml
+++ b/influxdb/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   # route 90% of traffic to app1, 10% to app2
   linkerd1:
-    image: buoyantio/linkerd:1.1.3
+    image: buoyantio/linkerd:1.2.0
     volumes:
     - ./linkerd1.yml:/io.buoyant/linkerd/config.yml:ro
     - ./disco:/disco:ro
@@ -27,7 +27,7 @@ services:
 
   # route 25% of traffic to app1, 75% to app2
   linkerd2:
-    image: buoyantio/linkerd:1.1.3
+    image: buoyantio/linkerd:1.2.0
     volumes:
     - ./linkerd2.yml:/io.buoyant/linkerd/config.yml:ro
     - ./disco:/disco:ro

--- a/influxdb/linkerd1.yml
+++ b/influxdb/linkerd1.yml
@@ -1,4 +1,5 @@
 admin:
+  ip: 0.0.0.0
   port: 9990
 
 # use the filesystem namer, read from the local /disco directory

--- a/influxdb/linkerd2.yml
+++ b/influxdb/linkerd2.yml
@@ -1,4 +1,5 @@
 admin:
+  ip: 0.0.0.0
   port: 9990
 
 # use the filesystem namer, read from the local /disco directory

--- a/istio/helloworld-grpc-minikube/istio-ingress.yml
+++ b/istio/helloworld-grpc-minikube/istio-ingress.yml
@@ -48,7 +48,7 @@ spec:
           name: "istio-ingress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/istio/istio-daemonset-grpc.yml
+++ b/istio/istio-daemonset-grpc.yml
@@ -9,6 +9,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     telemetry:
@@ -74,7 +75,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/istio/istio-daemonset.yml
+++ b/istio/istio-daemonset.yml
@@ -9,6 +9,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     telemetry:
@@ -73,7 +74,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/istio/istio-egress.yml
+++ b/istio/istio-egress.yml
@@ -9,6 +9,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     telemetry:
@@ -55,7 +56,7 @@ spec:
           name: "istio-egress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:

--- a/istio/istio-ingress.yml
+++ b/istio/istio-ingress.yml
@@ -8,6 +8,10 @@ metadata:
   name: istio-ingress-config
 data:
   config.yaml: |-
+    admin:
+      ip: 0.0.0.0
+      port: 9990
+
     telemetry:
     - kind: io.l5d.prometheus
     - kind: io.l5d.recentRequests
@@ -51,7 +55,7 @@ spec:
           name: "istio-ingress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/istio/istio-linkerd.yml
+++ b/istio/istio-linkerd.yml
@@ -133,6 +133,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     telemetry:
@@ -194,7 +195,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:
@@ -251,6 +252,10 @@ metadata:
   name: istio-ingress-config
 data:
   config.yaml: |-
+    admin:
+      ip: 0.0.0.0
+      port: 9990
+
     telemetry:
     - kind: io.l5d.prometheus
     - kind: io.l5d.recentRequests
@@ -291,7 +296,7 @@ spec:
           name: "istio-ingress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:
@@ -342,6 +347,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     telemetry:
@@ -388,7 +394,7 @@ spec:
           name: "istio-egress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:

--- a/k8s-daemonset/README.md
+++ b/k8s-daemonset/README.md
@@ -225,7 +225,7 @@ If you deployed namerd, view the namerd admin dashboard:
 
 ```bash
 NAMERD_INGRESS_LB=$(kubectl get svc namerd -o jsonpath="{.status.loadBalancer.ingress[0].*}")
-open http://$NAMERD_INGRESS_LB:9990 # on OS X
+open http://$NAMERD_INGRESS_LB:9991 # on OS X
 ```
 
 ### Zipkin

--- a/k8s-daemonset/k8s/linkerd-cni-legacy.yml
+++ b/k8s-daemonset/k8s/linkerd-cni-legacy.yml
@@ -11,6 +11,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     namers:

--- a/k8s-daemonset/k8s/linkerd-cni.yml
+++ b/k8s-daemonset/k8s/linkerd-cni.yml
@@ -11,6 +11,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     namers:
@@ -86,7 +87,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: NODE_NAME
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-egress.yaml
+++ b/k8s-daemonset/k8s/linkerd-egress.yaml
@@ -7,6 +7,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     namers:
@@ -83,7 +84,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-grpc.yml
+++ b/k8s-daemonset/k8s/linkerd-grpc.yml
@@ -7,6 +7,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     namers:
@@ -83,7 +84,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-ingress-controller.yml
+++ b/k8s-daemonset/k8s/linkerd-ingress-controller.yml
@@ -5,6 +5,10 @@ metadata:
   name: l5d-config
 data:
   config.yaml: |-
+    admin:
+      ip: 0.0.0.0
+      port: 9990
+
     namers:
     - kind: io.l5d.k8s
 
@@ -39,7 +43,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-ingress.yml
+++ b/k8s-daemonset/k8s/linkerd-ingress.yml
@@ -7,6 +7,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     namers:
@@ -100,7 +101,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-latency.yml
+++ b/k8s-daemonset/k8s/linkerd-latency.yml
@@ -7,6 +7,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     namers:
@@ -79,7 +80,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-namerd.yml
+++ b/k8s-daemonset/k8s/linkerd-namerd.yml
@@ -8,6 +8,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     telemetry:
@@ -77,7 +78,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-tls-ingress-controller.yml
+++ b/k8s-daemonset/k8s/linkerd-tls-ingress-controller.yml
@@ -5,6 +5,10 @@ metadata:
   name: l5d-config
 data:
   config.yaml: |-
+    admin:
+      ip: 0.0.0.0
+      port: 9990
+
     namers:
     - kind: io.l5d.k8s
 
@@ -45,7 +49,7 @@ spec:
           secretName: ingress-certs
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-tls.yml
+++ b/k8s-daemonset/k8s/linkerd-tls.yml
@@ -8,6 +8,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     namers:
@@ -90,7 +91,7 @@ spec:
           secretName: certificates
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-zipkin.yml
+++ b/k8s-daemonset/k8s/linkerd-zipkin.yml
@@ -7,6 +7,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     namers:
@@ -82,7 +83,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd.yml
+++ b/k8s-daemonset/k8s/linkerd.yml
@@ -7,6 +7,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip: 0.0.0.0
       port: 9990
 
     namers:
@@ -78,7 +79,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/namerd.yml
+++ b/k8s-daemonset/k8s/namerd.yml
@@ -14,7 +14,8 @@ metadata:
 data:
   config.yml: |-
     admin:
-      port: 9990
+      ip: 0.0.0.0
+      port: 9991
 
     namers:
     - kind: io.l5d.k8s
@@ -56,7 +57,7 @@ spec:
           name: namerd-config
       containers:
       - name: namerd
-        image: buoyantio/namerd:1.1.3
+        image: buoyantio/namerd:1.2.0
         args:
         - /io.buoyant/namerd/config/config.yml
         ports:
@@ -65,7 +66,7 @@ spec:
         - name: http
           containerPort: 4180
         - name: admin
-          containerPort: 9990
+          containerPort: 9991
         volumeMounts:
         - name: "namerd-config"
           mountPath: "/io.buoyant/namerd/config"
@@ -91,7 +92,7 @@ spec:
   - name: http
     port: 4180
   - name: admin
-    port: 9990
+    port: 9991
 ---
 kind: ConfigMap
 apiVersion: v1

--- a/k8s-daemonset/k8s/servicemesh.yml
+++ b/k8s-daemonset/k8s/servicemesh.yml
@@ -47,6 +47,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
+      ip 0.0.0.0
       port: 9990
 
     # Namers provide Linkerd with service discovery information.  To use a
@@ -295,7 +296,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.1.3
+        image: buoyantio/linkerd:1.2.0
         env:
         - name: POD_IP
           valueFrom:

--- a/linkerd-tcp/docker-compose.yml
+++ b/linkerd-tcp/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     - "-redis-addr=linkerd-tcp:7474"
 
   linkerd:
-    image: buoyantio/linkerd:1.1.3
+    image: buoyantio/linkerd:1.2.0
     ports:
     - 4140:4140 # expose for testing only
     - 9990:9990
@@ -72,7 +72,7 @@ services:
     - "/io.buoyant/linkerd/config.yml"
 
   namerd:
-    image: buoyantio/namerd:1.1.3
+    image: buoyantio/namerd:1.2.0
     ports:
     - 4180:4180
     - 9991:9991

--- a/linkerd-tcp/linkerd.yml
+++ b/linkerd-tcp/linkerd.yml
@@ -1,3 +1,7 @@
+admin:
+  ip: 0.0.0.0
+  port: 9990
+
 telemetry:
 - kind: io.l5d.prometheus
 - kind: io.l5d.recentRequests

--- a/linkerd-tcp/namerd.yml
+++ b/linkerd-tcp/namerd.yml
@@ -1,4 +1,5 @@
 admin:
+  ip: 0.0.0.0
   port: 9991
 
 namers:

--- a/mesos-marathon/linkerd-config.yml
+++ b/mesos-marathon/linkerd-config.yml
@@ -3,6 +3,7 @@
 # expects marathon to be available on localhost
 
 admin:
+  ip: 0.0.0.0
   port: 9990
 
 telemetry:

--- a/mesos-marathon/linkerd-marathon.json
+++ b/mesos-marathon/linkerd-marathon.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.1.3",
+      "image": "buoyantio/linkerd:1.2.0",
       "network": "HOST",
       "privileged": true
     }
@@ -36,5 +36,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"localhost\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.1.3/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"localhost\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.2.0/bundle-exec -log.level=DEBUG -com.twitter.finagle.tracing.debugTrace=true -- -"
 }

--- a/plugins/build.sbt
+++ b/plugins/build.sbt
@@ -6,7 +6,7 @@ def finagle(mod: String) =
   "com.twitter" %% s"finagle-$mod" % "6.45.0"
 
 def linkerd(mod: String) =
-  "io.buoyant" %% s"linkerd-$mod" % "1.1.3"
+  "io.buoyant" %% s"linkerd-$mod" % "1.2.0"
 
 val headerClassifier =
   project.in(file("header-classifier")).


### PR DESCRIPTION
In addition to linkerd version bump, primary change includes modifying
linkerd and namerd admin servers to serve on 0.0.0.0, rather than the
new default loopback.