### PR TITLE
Fix typo in k8s daemons servicemesh ip config

### DIFF
--- a/k8s-daemonset/k8s/servicemesh.yml
+++ b/k8s-daemonset/k8s/servicemesh.yml
@@ -47,7 +47,7 @@ metadata:
 data:
   config.yaml: |-
     admin:
-      ip 0.0.0.0
+      ip: 0.0.0.0
       port: 9990
 
     # Namers provide Linkerd with service discovery information.  To use a


### PR DESCRIPTION
This small typo prevents running the examples from the recent blog post and pods
just die with CrashLoopBackOff due to the following error:

```
INFO: HttpMuxer[/admin/per_host_metrics.json] = com.twitter.finagle.stats.HostMetricsExporter(<function1>)
I 0912 19:42:08.876 UTC THREAD1: linkerd 1.2.0 (rev=7868f5195a87253c1a362923bea1f019d4821226) built at 20170907-175131
I 0912 19:42:09.069 UTC THREAD1: Finagle version 6.45.0 (rev=fadc80cdd804f2885ebc213964542d5568a4f485) built at 20170609-103217
com.fasterxml.jackson.databind.JsonMappingException: Can not construct instance of io.buoyant.admin.AdminConfig: no String-argument constructor/factory method to deserialize from S
tring value ('ip 0.0.0.0 port')
```