### PR TITLE
Update linkerd logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,5 +149,5 @@ docker run -v `pwd`:/root/linkerd-examples --entrypoint=/root/linkerd-examples/.
 <!-- references -->
 [l5d-ci]: https://circleci.com/gh/linkerd/linkerd-examples
 [l5d-ci-badge]: https://circleci.com/gh/linkerd/linkerd-examples.svg?style=shield
-[l5d-logo]: https://cloud.githubusercontent.com/assets/9226/12433413/c6fff880-beb5-11e5-94d1-1afb1258f464.png
+[l5d-logo]: https://user-images.githubusercontent.com/9226/33582867-3e646e02-d90c-11e7-85a2-2e238737e859.png
 [license-badge]: https://img.shields.io/github/license/linkerd/linkerd-examples.svg


### PR DESCRIPTION
Updating the README to the latest linkerd logo. You can view it here:

https://github.com/linkerd/linkerd-examples/blob/kl/new-logo/README.md