### PR TITLE
Update linkerd-tcp example to 0.1.1

### DIFF
--- a/linkerd-tcp/docker-compose.yml
+++ b/linkerd-tcp/docker-compose.yml
@@ -83,7 +83,7 @@ services:
     - "/io.buoyant/namerd/config.yml"
 
   linkerd-tcp:
-    image: linkerd/linkerd-tcp:0.0.3
+    image: linkerd/linkerd-tcp:0.1.1
     ports:
     - 9992:9992
     volumes:

--- a/linkerd-tcp/grafana.json
+++ b/linkerd-tcp/grafana.json
@@ -4,6 +4,7 @@
   },
   "editable": true,
   "gnetId": null,
+  "graphTooltip": 0,
   "hideControls": false,
   "id": 1,
   "links": [],
@@ -11,24 +12,19 @@
   "rows": [
     {
       "collapse": false,
-      "editable": true,
       "height": "250px",
       "panels": [
         {
           "aliasColors": {},
           "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "editable": true,
           "error": false,
           "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "grid": {},
           "id": 1,
-          "isNew": true,
           "legend": {
             "avg": false,
             "current": false,
@@ -47,6 +43,7 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 6,
           "stack": false,
           "steppedLine": false,
@@ -59,6 +56,7 @@
               "step": 2
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
           "title": "Requests Served",
@@ -70,7 +68,11 @@
           },
           "type": "graph",
           "xaxis": {
-            "show": true
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
           },
           "yaxes": [
             {
@@ -94,18 +96,14 @@
         {
           "aliasColors": {},
           "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "editable": true,
           "error": false,
           "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "grid": {},
           "id": 4,
-          "isNew": true,
           "legend": {
             "avg": false,
             "current": false,
@@ -124,6 +122,7 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 6,
           "stack": false,
           "steppedLine": false,
@@ -137,6 +136,7 @@
               "step": 2
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
           "title": "Percentile Latency",
@@ -148,7 +148,11 @@
           },
           "type": "graph",
           "xaxis": {
-            "show": true
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
           },
           "yaxes": [
             {
@@ -170,29 +174,28 @@
           ]
         }
       ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
       "showTitle": true,
-      "title": "linkerd"
+      "title": "linkerd",
+      "titleSize": "h6"
     },
     {
       "collapse": false,
-      "editable": true,
       "height": "250px",
       "panels": [
         {
           "aliasColors": {},
           "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "editable": true,
           "error": false,
           "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "grid": {},
           "id": 2,
-          "isNew": true,
           "legend": {
             "avg": false,
             "current": false,
@@ -211,19 +214,30 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "irate(bytes_total[1m])",
+              "expr": "irate(l5d:srv:stream:rx_bytes[1m])",
+              "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
-              "legendFormat": "{{direction}} bytes",
+              "legendFormat": "rx bytes",
               "refId": "A",
               "step": 2
+            },
+            {
+              "expr": "irate(l5d:srv:stream:tx_bytes[1m])",
+              "format": "time_series",
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "tx bytes",
+              "refId": "B"
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
           "title": "Connection Bytes",
@@ -235,7 +249,11 @@
           },
           "type": "graph",
           "xaxis": {
-            "show": true
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
           },
           "yaxes": [
             {
@@ -259,18 +277,14 @@
         {
           "aliasColors": {},
           "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "editable": true,
           "error": false,
           "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "grid": {},
           "id": 5,
-          "isNew": true,
           "legend": {
             "avg": false,
             "current": false,
@@ -289,18 +303,21 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "conns_active",
+              "expr": "l5d:balancer:connection:open",
+              "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "connections",
               "refId": "A",
               "step": 2
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
           "title": "Active Connections",
@@ -312,7 +329,11 @@
           },
           "type": "graph",
           "xaxis": {
-            "show": true
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
           },
           "yaxes": [
             {
@@ -334,29 +355,28 @@
           ]
         }
       ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
       "showTitle": true,
-      "title": "linkerd-tcp"
+      "title": "linkerd-tcp",
+      "titleSize": "h6"
     },
     {
       "collapse": false,
-      "editable": true,
       "height": "250px",
       "panels": [
         {
           "aliasColors": {},
           "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "editable": true,
           "error": false,
           "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "grid": {},
           "id": 3,
-          "isNew": true,
           "legend": {
             "avg": false,
             "current": false,
@@ -375,6 +395,7 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 6,
           "stack": false,
           "steppedLine": false,
@@ -389,6 +410,7 @@
               "step": 2
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
           "title": "Commands",
@@ -400,7 +422,11 @@
           },
           "type": "graph",
           "xaxis": {
-            "show": true
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
           },
           "yaxes": [
             {
@@ -424,18 +450,14 @@
         {
           "aliasColors": {},
           "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": null,
           "editable": true,
           "error": false,
           "fill": 1,
-          "grid": {
-            "threshold1": null,
-            "threshold1Color": "rgba(216, 200, 27, 0.27)",
-            "threshold2": null,
-            "threshold2Color": "rgba(234, 112, 112, 0.22)"
-          },
+          "grid": {},
           "id": 6,
-          "isNew": true,
           "legend": {
             "avg": false,
             "current": false,
@@ -454,6 +476,7 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 6,
           "stack": false,
           "steppedLine": false,
@@ -466,6 +489,7 @@
               "step": 2
             }
           ],
+          "thresholds": [],
           "timeFrom": null,
           "timeShift": null,
           "title": "Client Connections",
@@ -477,7 +501,11 @@
           },
           "type": "graph",
           "xaxis": {
-            "show": true
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
           },
           "yaxes": [
             {
@@ -499,12 +527,15 @@
           ]
         }
       ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
       "showTitle": true,
-      "title": "redis"
+      "title": "redis",
+      "titleSize": "h6"
     }
   ],
-  "schemaVersion": 12,
-  "sharedCrosshair": false,
+  "schemaVersion": 14,
   "style": "dark",
   "tags": [],
   "templating": {

--- a/linkerd-tcp/linkerd-tcp.yml
+++ b/linkerd-tcp/linkerd-tcp.yml
@@ -1,18 +1,21 @@
 # the admin section defines where to serve the admin interface, and how
-# frequently to refresh metrics served
+# frequently to refresh metrics served.
 admin:
-  addr: 0.0.0.0:9992
+  ip: 0.0.0.0
+  port: 9992
   metricsIntervalSecs: 5
 
-# the proxies section defines a list of proxies. each proxy defines one or more
-# servers, each serving on a different address. proxies resolve routes using a
-# configured namerd address, namespace, and static path.
-proxies:
+# the routers section defines a list of routers. each router defines one or more
+# servers, each serving on a different address. routers resolve routes using a
+# configured interpreter, in this case the namerd http interpreter.
+routers:
 - label: redis
   servers:
-  - kind: io.l5d.tcp
-    addr: 0.0.0.0:7474
-  namerd:
-    url: http://namerd:4180
-    path: /svc/redis
-    intervalSecs: 5
+  - ip: 0.0.0.0
+    port: 7474
+    dstName: /svc/redis
+  interpreter:
+    kind: io.l5d.namerd.http
+    baseUrl: http://namerd:4180
+    namespace: default
+    periodSecs: 20


### PR DESCRIPTION
I heard that linkerd-tcp 0.1.1 is all the rage. This branch updates our example to use it, and required some changes to the linkerd-tcp config file and the metrics displayed in the grafana dashboard.