### PR TITLE
Remove TLS interfaces from sample namerd configs

### DIFF
--- a/k8s-daemonset/k8s/linkerd-namerd-cni.yml
+++ b/k8s-daemonset/k8s/linkerd-namerd-cni.yml
@@ -59,11 +59,8 @@ data:
       label: outgoing-tls
       interpreter:
         kind: io.l5d.namerd
-        dst: /$/inet/namerd.default.svc.cluster.local/4101
+        dst: /$/inet/namerd.default.svc.cluster.local/4100
         namespace: internal
-        tls:
-          commonName: linkerd
-          caCert: /io.buoyant/linkerd/certs/cacertificate.pem
         transformers:
         - kind: io.l5d.k8s.daemonset
           namespace: default
@@ -81,11 +78,8 @@ data:
       label: incoming-tls
       interpreter:
         kind: io.l5d.namerd
-        dst: /$/inet/namerd.default.svc.cluster.local/4101
+        dst: /$/inet/namerd.default.svc.cluster.local/4100
         namespace: internal
-        tls:
-          commonName: linkerd
-          caCert: /io.buoyant/linkerd/certs/cacertificate.pem
         transformers:
         - kind: io.l5d.k8s.localnode
           hostNetwork: true
@@ -132,12 +126,8 @@ data:
       interpreter:
         kind: io.l5d.mesh
         experimental: true
-        dst: /$/inet/namerd.default.svc.cluster.local/4322
+        dst: /$/inet/namerd.default.svc.cluster.local/4321
         root: /internal
-        tls:
-          commonName: linkerd
-          trustCerts:
-          - /io.buoyant/linkerd/certs/cacertificate.pem
         transformers:
         - kind: io.l5d.k8s.daemonset
           namespace: default
@@ -156,12 +146,8 @@ data:
       interpreter:
         kind: io.l5d.mesh
         experimental: true
-        dst: /$/inet/namerd.default.svc.cluster.local/4322
+        dst: /$/inet/namerd.default.svc.cluster.local/4321
         root: /internal
-        tls:
-          commonName: linkerd
-          trustCerts:
-          - /io.buoyant/linkerd/certs/cacertificate.pem
         transformers:
         - kind: io.l5d.k8s.localnode
           hostNetwork: true

--- a/k8s-daemonset/k8s/namerd-legacy.yml
+++ b/k8s-daemonset/k8s/namerd-legacy.yml
@@ -33,31 +33,12 @@ data:
     - kind: io.l5d.thriftNameInterpreter
       ip: 0.0.0.0
       port: 4100
-    - kind: io.l5d.thriftNameInterpreter
-      ip: 0.0.0.0
-      port: 4101
-      tls:
-        certPath: /io.buoyant/namerd/certs/certificate.pem
-        keyPath: /io.buoyant/namerd/certs/key.pk8
     - kind: io.l5d.httpController
       ip: 0.0.0.0
       port: 4180
-    - kind: io.l5d.httpController
-      ip: 0.0.0.0
-      port: 4181
-      tls:
-        certPath: /io.buoyant/namerd/certs/certificate.pem
-        keyPath: /io.buoyant/namerd/certs/key.pk8
     - kind: io.l5d.mesh
       ip: 0.0.0.0
       port: 4321
-    - kind: io.l5d.mesh
-      ip: 0.0.0.0
-      port: 4322
-      tls:
-        certPath: /io.buoyant/namerd/certs/certificate.pem
-        keyPath: /io.buoyant/namerd/certs/key.pk8
-
 ---
 kind: ReplicationController
 apiVersion: v1
@@ -77,9 +58,6 @@ spec:
       - name: namerd-config
         configMap:
           name: namerd-config
-      - name: certificates
-        secret:
-          secretName: certificates
       containers:
       - name: namerd
         image: buoyantio/namerd:1.3.5
@@ -88,24 +66,15 @@ spec:
         ports:
         - name: thrift
           containerPort: 4100
-        - name: thrift-tls
-          containerPort: 4101
         - name: http
           containerPort: 4180
-        - name: http-tls
-          containerPort: 4181
         - name: mesh
           containerPort: 4321
-        - name: mesh-tls
-          containerPort: 4322
         - name: admin
           containerPort: 9991
         volumeMounts:
         - name: "namerd-config"
           mountPath: "/io.buoyant/namerd/config"
-          readOnly: true
-        - name: "certificates"
-          mountPath: "/io.buoyant/namerd/certs"
           readOnly: true
       - name: kubectl
         image: buoyantio/kubectl:v1.8.5
@@ -125,16 +94,10 @@ spec:
   ports:
   - name: thrift
     port: 4100
-  - name: thrift-tls
-    port: 4101
   - name: http
     port: 4180
-  - name: http-tls
-    port: 4181
   - name: mesh
     port: 4321
-  - name: mesh-tls
-    port: 4322
   - name: admin
     port: 9991
 ---

--- a/k8s-daemonset/k8s/namerd.yml
+++ b/k8s-daemonset/k8s/namerd.yml
@@ -38,31 +38,12 @@ data:
     - kind: io.l5d.thriftNameInterpreter
       ip: 0.0.0.0
       port: 4100
-    - kind: io.l5d.thriftNameInterpreter
-      ip: 0.0.0.0
-      port: 4101
-      tls:
-        certPath: /io.buoyant/namerd/certs/certificate.pem
-        keyPath: /io.buoyant/namerd/certs/key.pk8
     - kind: io.l5d.httpController
       ip: 0.0.0.0
       port: 4180
-    - kind: io.l5d.httpController
-      ip: 0.0.0.0
-      port: 4181
-      tls:
-        certPath: /io.buoyant/namerd/certs/certificate.pem
-        keyPath: /io.buoyant/namerd/certs/key.pk8
     - kind: io.l5d.mesh
       ip: 0.0.0.0
       port: 4321
-    - kind: io.l5d.mesh
-      ip: 0.0.0.0
-      port: 4322
-      tls:
-        certPath: /io.buoyant/namerd/certs/certificate.pem
-        keyPath: /io.buoyant/namerd/certs/key.pk8
-
 ---
 kind: ReplicationController
 apiVersion: v1
@@ -82,9 +63,6 @@ spec:
       - name: namerd-config
         configMap:
           name: namerd-config
-      - name: certificates
-        secret:
-          secretName: certificates
       containers:
       - name: namerd
         image: buoyantio/namerd:1.3.5
@@ -93,24 +71,15 @@ spec:
         ports:
         - name: thrift
           containerPort: 4100
-        - name: thrift-tls
-          containerPort: 4101
         - name: http
           containerPort: 4180
-        - name: http-tls
-          containerPort: 4181
         - name: mesh
           containerPort: 4321
-        - name: mesh-tls
-          containerPort: 4322
         - name: admin
           containerPort: 9991
         volumeMounts:
         - name: "namerd-config"
           mountPath: "/io.buoyant/namerd/config"
-          readOnly: true
-        - name: "certificates"
-          mountPath: "/io.buoyant/namerd/certs"
           readOnly: true
       - name: kubectl
         image: buoyantio/kubectl:v1.8.5
@@ -130,16 +99,10 @@ spec:
   ports:
   - name: thrift
     port: 4100
-  - name: thrift-tls
-    port: 4101
   - name: http
     port: 4180
-  - name: http-tls
-    port: 4181
   - name: mesh
     port: 4321
-  - name: mesh-tls
-    port: 4322
   - name: admin
     port: 9991
 ---


### PR DESCRIPTION
Our namerd sample configs were reconfigured to start serving all of their interfaces over TLS as part of #188. This requires that the namerd containers volume mount certificates, but none of our examples explain how to create the certificate secret, which is [confusing](https://discourse.linkerd.io/t/following-blog-post-but-namerd-complains-about-certificates/555). I'm removing the TLS interfaces so that namerd pods will start without requiring that the certificate secret be created first.

The only config that was using the TLS interfaces was k8s/linkerd-namerd-cni-tls.yml, so I've modified it to use the non-TLS interfaces. It's still the case that that config uses TLS for linker-to-linker requests; it just no longer uses TLS when talking to namerd.