### PR TITLE
Linkerd 1.3.6 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Contains sample code for building linkerd plugins. More information:
 ## Testing
 
 ```bash
-docker run -v `pwd`:/root/linkerd-examples --entrypoint=/root/linkerd-examples/.circleci/ci.sh buoyantio/linkerd:1.3.5
+docker run -v `pwd`:/root/linkerd-examples --entrypoint=/root/linkerd-examples/.circleci/ci.sh buoyantio/linkerd:1.3.6
 ```
 
 <!-- references -->

--- a/add-steps/docker-compose.yml
+++ b/add-steps/docker-compose.yml
@@ -121,7 +121,7 @@ services:
     command: -latency=2s -success-rate=0.4
 
   linkerd:
-    image: buoyantio/linkerd:1.3.5
+    image: buoyantio/linkerd:1.3.6
     ports:
       - 4140:4140
       - 9990:9990

--- a/consul/docker-compose.yml
+++ b/consul/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "7777:7777"
 
   linkerd:
-    image: buoyantio/linkerd:1.3.5
+    image: buoyantio/linkerd:1.3.6
     command: ['/config.yaml']
     links:
       - consul

--- a/dcos/ingress/linkerd-dcos.json
+++ b/dcos/ingress/linkerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.3.5",
+      "image": "buoyantio/linkerd:1.3.6",
       "network": "HOST",
       "privileged": true
     }
@@ -38,5 +38,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4242,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/svc/*=>/#/io.l5d.marathon/webapp;\\\",\\\"label\\\":\\\"external\\\"}]}\" | /io.buoyant/linkerd/1.3.5/bundle-exec -log.level=DEBUG -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4242,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/svc/*=>/#/io.l5d.marathon/webapp;\\\",\\\"label\\\":\\\"external\\\"}]}\" | /io.buoyant/linkerd/1.3.6/bundle-exec -log.level=DEBUG -- -"
 }

--- a/dcos/linker-to-linker-with-namerd/linkerd-dcos.json
+++ b/dcos/linker-to-linker-with-namerd/linkerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.3.5",
+      "image": "buoyantio/linkerd:1.3.6",
       "network": "HOST",
       "privileged": true
     }
@@ -38,5 +38,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"outgoing\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.mesos/4100\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.port\\\",\\\"port\\\":4141}]}},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4141,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"incoming\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.mesos/4100\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.localhost\\\"}]}}]}\" | /io.buoyant/linkerd/1.3.5/bundle-exec -log.level=DEBUG -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"outgoing\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.mesos/4100\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.port\\\",\\\"port\\\":4141}]}},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4141,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"incoming\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.mesos/4100\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.localhost\\\"}]}}]}\" | /io.buoyant/linkerd/1.3.6/bundle-exec -log.level=DEBUG -- -"
 }

--- a/dcos/linker-to-linker/linkerd-dcos.json
+++ b/dcos/linker-to-linker/linkerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.3.5",
+      "image": "buoyantio/linkerd:1.3.6",
       "network": "HOST",
       "privileged": true
     }
@@ -38,5 +38,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"outgoing\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"default\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.port\\\",\\\"port\\\":4141}]}},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4141,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"incoming\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"default\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.localhost\\\"}]}}]}\" | /io.buoyant/linkerd/1.3.5/bundle-exec -log.level=DEBUG -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"outgoing\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"default\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.port\\\",\\\"port\\\":4141}]}},{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4141,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"incoming\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"default\\\",\\\"transformers\\\":[{\\\"kind\\\":\\\"io.l5d.localhost\\\"}]}}]}\" | /io.buoyant/linkerd/1.3.6/bundle-exec -log.level=DEBUG -- -"
 }

--- a/dcos/linkerd-marathon-auth/linkerd-dcos.json
+++ b/dcos/linkerd-marathon-auth/linkerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.3.5",
+      "image": "buoyantio/linkerd:1.3.6",
       "network": "HOST",
       "privileged": true
     }
@@ -41,5 +41,5 @@
     }
   },
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"leader.mesos\\\",\\\"port\\\":443,\\\"prefix\\\":\\\"/io.l5d.marathon\\\",\\\"uriPrefix\\\":\\\"/marathon\\\",\\\"tls\\\":{\\\"disableValidation\\\":false,\\\"commonName\\\":\\\"master.mesos\\\",\\\"trustCerts\\\":[\\\"/mnt/mesos/sandbox/.ssl/ca.crt\\\"]}}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.3.5/bundle-exec -log.level=DEBUG -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"leader.mesos\\\",\\\"port\\\":443,\\\"prefix\\\":\\\"/io.l5d.marathon\\\",\\\"uriPrefix\\\":\\\"/marathon\\\",\\\"tls\\\":{\\\"disableValidation\\\":false,\\\"commonName\\\":\\\"master.mesos\\\",\\\"trustCerts\\\":[\\\"/mnt/mesos/sandbox/.ssl/ca.crt\\\"]}}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.3.6/bundle-exec -log.level=DEBUG -- -"
 }

--- a/dcos/linkerd-with-namerd/linkerd-dcos.json
+++ b/dcos/linkerd-with-namerd/linkerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.3.5",
+      "image": "buoyantio/linkerd:1.3.6",
       "network": "HOST",
       "privileged": true
     }
@@ -33,5 +33,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"linkerd_proxy\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.mesos/4100\\\"}}]}\" | /io.buoyant/linkerd/1.3.5/bundle-exec -log.level=DEBUG -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"label\\\":\\\"linkerd_proxy\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.mesos/4100\\\"}}]}\" | /io.buoyant/linkerd/1.3.6/bundle-exec -log.level=DEBUG -- -"
 }

--- a/dcos/namerd/namerd-dcos.json
+++ b/dcos/namerd/namerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/namerd:1.3.5-dcos",
+      "image": "buoyantio/namerd:1.3.6-dcos",
       "network": "HOST",
       "privileged": true
     }
@@ -38,5 +38,5 @@
     }
   ],
   "requirePorts":true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9991},\\\"storage\\\":{\\\"kind\\\":\\\"io.l5d.zk\\\",\\\"zkAddrs\\\":[{\\\"host\\\":\\\"leader.mesos\\\",\\\"port\\\":2181}],\\\"pathPrefix\\\":\\\"/dtabs\\\",\\\"sessionTimeoutMs\\\":10000},\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"interfaces\\\":[{\\\"kind\\\":\\\"io.l5d.thriftNameInterpreter\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4100},{\\\"kind\\\":\\\"io.l5d.httpController\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4180}]}\" | /io.buoyant/namerd/1.3.5/dcos-exec -log.level=DEBUG -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9991},\\\"storage\\\":{\\\"kind\\\":\\\"io.l5d.zk\\\",\\\"zkAddrs\\\":[{\\\"host\\\":\\\"leader.mesos\\\",\\\"port\\\":2181}],\\\"pathPrefix\\\":\\\"/dtabs\\\",\\\"sessionTimeoutMs\\\":10000},\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"interfaces\\\":[{\\\"kind\\\":\\\"io.l5d.thriftNameInterpreter\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4100},{\\\"kind\\\":\\\"io.l5d.httpController\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4180}]}\" | /io.buoyant/namerd/1.3.6/dcos-exec -log.level=DEBUG -- -"
 }

--- a/dcos/simple-proxy/linkerd-dcos.json
+++ b/dcos/simple-proxy/linkerd-dcos.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.3.5",
+      "image": "buoyantio/linkerd:1.3.6",
       "network": "HOST",
       "privileged": true
     }
@@ -33,5 +33,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.3.5/bundle-exec -log.level=DEBUG -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.3.6/bundle-exec -log.level=DEBUG -- -"
 }

--- a/ecs/linkerd-task-definition.json
+++ b/ecs/linkerd-task-definition.json
@@ -2,7 +2,7 @@
   "containerDefinitions": [
     {
       "name": "linkerd",
-      "image": "docker.io/buoyantio/linkerd:1.3.5",
+      "image": "docker.io/buoyantio/linkerd:1.3.6",
       "command": [
         "-log.level=DEBUG",
         "/etc/linkerd/linkerd.yaml"

--- a/ecs/linkerd-viz-task-definition.json
+++ b/ecs/linkerd-viz-task-definition.json
@@ -2,7 +2,7 @@
   "containerDefinitions": [
     {
       "name": "linkerd-viz",
-      "image": "docker.io/buoyantio/linkerd-viz:0.1.7",
+      "image": "docker.io/buoyantio/linkerd-viz:0.1.8",
       "command": [
         "consul"
       ],

--- a/failure-accrual/docker-compose.yml
+++ b/failure-accrual/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     build: .
 
   linkerd:
-    image: buoyantio/linkerd:1.3.5
+    image: buoyantio/linkerd:1.3.6
     ports:
       - 9990:9990
     volumes:

--- a/getting-started/docker/docker-compose.yml
+++ b/getting-started/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   # linkerd
   l5d:
-    image: buoyantio/linkerd:1.3.5
+    image: buoyantio/linkerd:1.3.6
     ports:
     - "4140:4140"
     - "9990:9990"

--- a/getting-started/k8s/linkerd.yml
+++ b/getting-started/k8s/linkerd.yml
@@ -13,7 +13,6 @@ data:
 
     namers:
     - kind: io.l5d.k8s
-      experimental: true
       # kubectl proxy forwards localhost:8001 to the Kubernetes master API
       host: localhost
       port: 8001
@@ -46,7 +45,7 @@ spec:
     spec:
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         args:
         - "/io.buoyant/linkerd/config/config.yml"
         ports:

--- a/gob/config/linkerd.yml
+++ b/gob/config/linkerd.yml
@@ -8,7 +8,6 @@ routers:
     ip: 0.0.0.0
 
 - protocol: h2
-  experimental: true
   interpreter:
     kind: io.l5d.namerd
     dst: /$/inet/namerd/4100

--- a/gob/dcos/linkerd-dcos-gob.yaml
+++ b/gob/dcos/linkerd-dcos-gob.yaml
@@ -12,7 +12,6 @@ routers:
     ip: 0.0.0.0
 
 - protocol: h2
-  experimental: true
   interpreter:
     kind: io.l5d.namerd
     dst: /$/inet/namerd.marathon.slave.mesos/4100

--- a/gob/dcos/marathon/linkerd.json
+++ b/gob/dcos/marathon/linkerd.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.3.5",
+      "image": "buoyantio/linkerd:1.3.6",
       "network": "HOST",
       "privileged": true
     }
@@ -38,5 +38,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.slave.mesos/4100\\\"},\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}]},{\\\"protocol\\\":\\\"h2\\\",\\\"experimental\\\":true,\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.slave.mesos/4100\\\"},\\\"servers\\\":[{\\\"port\\\":4142,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dstPrefix\\\":\\\"/grpc\\\",\\\"identifier\\\":{\\\"kind\\\":\\\"io.l5d.header.path\\\"}}]}\" | /io.buoyant/linkerd/1.3.5/bundle-exec -log.level=DEBUG -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.slave.mesos/4100\\\"},\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}]},{\\\"protocol\\\":\\\"h2\\\",\\\"experimental\\\":true,\\\"interpreter\\\":{\\\"kind\\\":\\\"io.l5d.namerd\\\",\\\"dst\\\":\\\"/$/inet/namerd.marathon.slave.mesos/4100\\\"},\\\"servers\\\":[{\\\"port\\\":4142,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dstPrefix\\\":\\\"/grpc\\\",\\\"identifier\\\":{\\\"kind\\\":\\\"io.l5d.header.path\\\"}}]}\" | /io.buoyant/linkerd/1.3.6/bundle-exec -log.level=DEBUG -- -"
 }

--- a/gob/dcos/marathon/namerd.json
+++ b/gob/dcos/marathon/namerd.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/namerd:1.3.5-dcos",
+      "image": "buoyantio/namerd:1.3.6-dcos",
       "network": "HOST",
       "privileged": true
     }
@@ -38,5 +38,5 @@
     }
   ],
   "requirePorts":true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9991},\\\"storage\\\":{\\\"kind\\\":\\\"io.l5d.zk\\\",\\\"experimental\\\":true,\\\"zkAddrs\\\":[{\\\"host\\\":\\\"master.mesos\\\",\\\"port\\\":2181}],\\\"pathPrefix\\\":\\\"/dtabs\\\",\\\"sessionTimeoutMs\\\":10000},\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"experimental\\\":true,\\\"prefix\\\":\\\"/io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"interfaces\\\":[{\\\"kind\\\":\\\"io.l5d.thriftNameInterpreter\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4100},{\\\"kind\\\":\\\"io.l5d.httpController\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4180}]}\" | /io.buoyant/namerd/1.3.5/dcos-exec -log.level=DEBUG -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9991},\\\"storage\\\":{\\\"kind\\\":\\\"io.l5d.zk\\\",\\\"experimental\\\":true,\\\"zkAddrs\\\":[{\\\"host\\\":\\\"master.mesos\\\",\\\"port\\\":2181}],\\\"pathPrefix\\\":\\\"/dtabs\\\",\\\"sessionTimeoutMs\\\":10000},\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"experimental\\\":true,\\\"prefix\\\":\\\"/io.l5d.marathon\\\",\\\"host\\\":\\\"marathon.mesos\\\",\\\"port\\\":8080}],\\\"interfaces\\\":[{\\\"kind\\\":\\\"io.l5d.thriftNameInterpreter\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4100},{\\\"kind\\\":\\\"io.l5d.httpController\\\",\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":4180}]}\" | /io.buoyant/namerd/1.3.6/dcos-exec -log.level=DEBUG -- -"
 }

--- a/gob/dcos/namerd-dcos-gob.yaml
+++ b/gob/dcos/namerd-dcos-gob.yaml
@@ -3,7 +3,6 @@ admin:
   port: 9991
 storage:
   kind: io.l5d.zk
-  experimental: true
   zkAddrs:
   - host: master.mesos
     port: 2181
@@ -11,7 +10,6 @@ storage:
   sessionTimeoutMs: 10000
 namers:
 - kind:      io.l5d.marathon
-  experimental: true
   prefix:    /io.l5d.marathon
   host:      marathon.mesos
   port:      8080

--- a/gob/docker-compose.yml
+++ b/gob/docker-compose.yml
@@ -20,14 +20,14 @@ services:
     command: word
 
   linkerd:
-    image: buoyantio/linkerd:1.3.5
+    image: buoyantio/linkerd:1.3.6
     container_name: linkerd
     ports: ["4142:4142", "4141:4141", "9990:9990"]
     volumes: ["./config:/io.buoyant/linkerd/config:ro"]
     command: /io.buoyant/linkerd/config/linkerd.yml
 
   namerd:
-    image: buoyantio/namerd:1.3.5
+    image: buoyantio/namerd:1.3.6
     container_name: namerd
     ports: ["4100:4100", "4180:4180", "9991:9991"]
     volumes: ["./config:/io.buoyant/linkerd/config:ro"]

--- a/gob/k8s/gen-growthhack/rc.yml
+++ b/gob/k8s/gen-growthhack/rc.yml
@@ -32,7 +32,7 @@ spec:
               containerPort: 8080
 
         - name: l5d
-          image: buoyantio/linkerd:1.3.5
+          image: buoyantio/linkerd:1.3.6
           args:
             - "/io.buoyant/linkerd/config/config.yml"
 

--- a/gob/k8s/gen/rc.yml
+++ b/gob/k8s/gen/rc.yml
@@ -32,7 +32,7 @@ spec:
               containerPort: 8080
 
         - name: l5d
-          image: buoyantio/linkerd:1.3.5
+          image: buoyantio/linkerd:1.3.6
           args:
             - "/io.buoyant/linkerd/config/config.yml"
 

--- a/gob/k8s/linkerd.yml
+++ b/gob/k8s/linkerd.yml
@@ -17,7 +17,6 @@ data:
       dtab: /svc => /$/inet/127.1/8080
 
     - protocol: h2
-      experimental: true
       servers:
       - port: 4180
         ip: 0.0.0.0

--- a/gob/k8s/namerd/config.yml
+++ b/gob/k8s/namerd/config.yml
@@ -11,7 +11,6 @@ data:
       kind: io.l5d.inMemory
     namers:
       - kind: io.l5d.k8s
-        experimental: true
         host: 127.0.0.1
         port: 8001
     interfaces:

--- a/gob/k8s/namerd/rc.yml
+++ b/gob/k8s/namerd/rc.yml
@@ -21,7 +21,7 @@ spec:
 
       containers:
         - name: namerd
-          image: buoyantio/namerd:1.3.5
+          image: buoyantio/namerd:1.3.6
           args:
             - /io.buoyant/namerd/config/config.yml
           imagePullPolicy: Always

--- a/gob/k8s/web/rc.yml
+++ b/gob/k8s/web/rc.yml
@@ -34,7 +34,7 @@ spec:
               containerPort: 8080
 
         - name: l5d
-          image: buoyantio/linkerd:1.3.5
+          image: buoyantio/linkerd:1.3.6
           args:
             - /io.buoyant/linkerd/config/config.yml
 

--- a/gob/k8s/word/rc.yml
+++ b/gob/k8s/word/rc.yml
@@ -32,7 +32,7 @@ spec:
               containerPort: 8080
 
         - name: l5d
-          image: buoyantio/linkerd:1.3.5
+          image: buoyantio/linkerd:1.3.6
           args:
             - "/io.buoyant/linkerd/config/config.yml"
 

--- a/http-proxy/README.md
+++ b/http-proxy/README.md
@@ -12,9 +12,9 @@ echo "Hello world" > hello; python3 -m http.server 8888
 ## Setup linkerd
 
 ```bash
-curl -sLO https://github.com/linkerd/linkerd/releases/download/1.3.5/linkerd-1.3.5-exec
-chmod +x linkerd-1.3.5-exec
-./linkerd-1.3.5-exec ./linkerd.yaml
+curl -sLO https://github.com/linkerd/linkerd/releases/download/1.3.6/linkerd-1.3.6-exec
+chmod +x linkerd-1.3.6-exec
+./linkerd-1.3.6-exec ./linkerd.yaml
 ```
 
 ## Test

--- a/influxdb/docker-compose.yml
+++ b/influxdb/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 
   # route 90% of traffic to app1, 10% to app2
   linkerd1:
-    image: buoyantio/linkerd:1.3.5
+    image: buoyantio/linkerd:1.3.6
     volumes:
     - ./linkerd1.yml:/io.buoyant/linkerd/config.yml:ro
     - ./disco:/disco:ro
@@ -27,7 +27,7 @@ services:
 
   # route 25% of traffic to app1, 75% to app2
   linkerd2:
-    image: buoyantio/linkerd:1.3.5
+    image: buoyantio/linkerd:1.3.6
     volumes:
     - ./linkerd2.yml:/io.buoyant/linkerd/config.yml:ro
     - ./disco:/disco:ro

--- a/istio/helloworld-grpc-minikube/istio-ingress.yml
+++ b/istio/helloworld-grpc-minikube/istio-ingress.yml
@@ -15,7 +15,6 @@ data:
 
     routers:
     - protocol: h2
-      experimental: true
       identifier:
         kind: io.l5d.k8s.istio-ingress
       interpreter:
@@ -48,7 +47,7 @@ spec:
           name: "istio-ingress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/istio/istio-daemonset-grpc.yml
+++ b/istio/istio-daemonset-grpc.yml
@@ -22,7 +22,6 @@ data:
 
     routers:
     - protocol: h2
-      experimental: true
       label: outgoing
       identifier:
         kind: io.l5d.k8s.istio
@@ -44,7 +43,6 @@ data:
           kind: io.l5d.h2.retryableRead5XX
 
     - protocol: h2
-      experimental: true
       label: incoming
       identifier:
         kind: io.l5d.k8s.istio
@@ -75,7 +73,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/istio/istio-daemonset.yml
+++ b/istio/istio-daemonset.yml
@@ -74,7 +74,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/istio/istio-egress.yml
+++ b/istio/istio-egress.yml
@@ -56,7 +56,7 @@ spec:
           name: "istio-egress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:

--- a/istio/istio-ingress.yml
+++ b/istio/istio-ingress.yml
@@ -55,7 +55,7 @@ spec:
           name: "istio-ingress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/istio/istio-linkerd.yml
+++ b/istio/istio-linkerd.yml
@@ -195,7 +195,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:
@@ -296,7 +296,7 @@ spec:
           name: "istio-ingress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:
@@ -394,7 +394,7 @@ spec:
           name: "istio-egress-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         args:
         - /io.buoyant/linkerd/config/config.yaml
         ports:

--- a/k8s-daemonset/k8s/linkerd-cni-legacy.yml
+++ b/k8s-daemonset/k8s/linkerd-cni-legacy.yml
@@ -16,7 +16,6 @@ data:
 
     namers:
     - kind: io.l5d.k8s
-      experimental: true
       host: localhost
       port: 8001
 

--- a/k8s-daemonset/k8s/linkerd-cni.yml
+++ b/k8s-daemonset/k8s/linkerd-cni.yml
@@ -16,7 +16,6 @@ data:
 
     namers:
     - kind: io.l5d.k8s
-      experimental: true
       host: localhost
       port: 8001
 
@@ -87,7 +86,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: NODE_NAME
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-egress.yaml
+++ b/k8s-daemonset/k8s/linkerd-egress.yaml
@@ -84,7 +84,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-grpc.yml
+++ b/k8s-daemonset/k8s/linkerd-grpc.yml
@@ -12,7 +12,6 @@ data:
 
     namers:
     - kind: io.l5d.k8s
-      experimental: true
       host: localhost
       port: 8001
 
@@ -27,7 +26,6 @@ data:
     routers:
     - protocol: h2
       label: outgoing
-      experimental: true
       dtab: |
         /srv        => /#/io.l5d.k8s/default/grpc;
         /grpc       => /srv;
@@ -49,7 +47,6 @@ data:
 
     - protocol: h2
       label: incoming
-      experimental: true
       dtab: |
         /srv        => /#/io.l5d.k8s/default/grpc;
         /grpc       => /srv;
@@ -84,7 +81,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-ingress-controller.yml
+++ b/k8s-daemonset/k8s/linkerd-ingress-controller.yml
@@ -43,7 +43,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-ingress.yml
+++ b/k8s-daemonset/k8s/linkerd-ingress.yml
@@ -12,7 +12,6 @@ data:
 
     namers:
     - kind: io.l5d.k8s
-      experimental: true
       host: localhost
       port: 8001
 
@@ -101,7 +100,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-latency.yml
+++ b/k8s-daemonset/k8s/linkerd-latency.yml
@@ -80,7 +80,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-namerd-cni.yml
+++ b/k8s-daemonset/k8s/linkerd-namerd-cni.yml
@@ -91,7 +91,6 @@ data:
       label: outgoing-mesh
       interpreter:
         kind: io.l5d.mesh
-        experimental: true
         dst: /$/inet/namerd.default.svc.cluster.local/4321
         root: /internal
         transformers:
@@ -111,7 +110,6 @@ data:
       label: incoming-mesh
       interpreter:
         kind: io.l5d.mesh
-        experimental: true
         dst: /$/inet/namerd.default.svc.cluster.local/4321
         root: /internal
         transformers:
@@ -125,7 +123,6 @@ data:
       label: out-mesh-tls
       interpreter:
         kind: io.l5d.mesh
-        experimental: true
         dst: /$/inet/namerd.default.svc.cluster.local/4321
         root: /internal
         transformers:
@@ -145,7 +142,6 @@ data:
       label: in-mesh-tls
       interpreter:
         kind: io.l5d.mesh
-        experimental: true
         dst: /$/inet/namerd.default.svc.cluster.local/4321
         root: /internal
         transformers:
@@ -179,7 +175,7 @@ spec:
           secretName: certificates
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: NODE_NAME
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-namerd.yml
+++ b/k8s-daemonset/k8s/linkerd-namerd.yml
@@ -78,7 +78,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-tls-ingress-controller.yml
+++ b/k8s-daemonset/k8s/linkerd-tls-ingress-controller.yml
@@ -49,7 +49,7 @@ spec:
           secretName: ingress-certs
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-tls.yml
+++ b/k8s-daemonset/k8s/linkerd-tls.yml
@@ -13,7 +13,6 @@ data:
 
     namers:
     - kind: io.l5d.k8s
-      experimental: true
       host: localhost
       port: 8001
 
@@ -91,7 +90,7 @@ spec:
           secretName: certificates
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd-zipkin.yml
+++ b/k8s-daemonset/k8s/linkerd-zipkin.yml
@@ -12,7 +12,6 @@ data:
 
     namers:
     - kind: io.l5d.k8s
-      experimental: true
       host: localhost
       port: 8001
 
@@ -83,7 +82,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/linkerd.yml
+++ b/k8s-daemonset/k8s/linkerd.yml
@@ -12,7 +12,6 @@ data:
 
     namers:
     - kind: io.l5d.k8s
-      experimental: true
       host: localhost
       port: 8001
 
@@ -79,7 +78,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/k8s-daemonset/k8s/namerd-legacy.yml
+++ b/k8s-daemonset/k8s/namerd-legacy.yml
@@ -19,7 +19,6 @@ data:
 
     namers:
     - kind: io.l5d.k8s
-      experimental: true
       host: localhost
       port: 8001
 
@@ -60,7 +59,7 @@ spec:
           name: namerd-config
       containers:
       - name: namerd
-        image: buoyantio/namerd:1.3.5
+        image: buoyantio/namerd:1.3.6
         args:
         - /io.buoyant/namerd/config/config.yml
         ports:

--- a/k8s-daemonset/k8s/namerd.yml
+++ b/k8s-daemonset/k8s/namerd.yml
@@ -24,7 +24,6 @@ data:
 
     namers:
     - kind: io.l5d.k8s
-      experimental: true
       host: localhost
       port: 8001
 
@@ -65,7 +64,7 @@ spec:
           name: namerd-config
       containers:
       - name: namerd
-        image: buoyantio/namerd:1.3.5
+        image: buoyantio/namerd:1.3.6
         args:
         - /io.buoyant/namerd/config/config.yml
         ports:

--- a/k8s-daemonset/k8s/servicemesh.yml
+++ b/k8s-daemonset/k8s/servicemesh.yml
@@ -173,7 +173,6 @@ data:
 
     - label: h2-outgoing
       protocol: h2
-      experimental: true
       servers:
       - port: 4240
         ip: 0.0.0.0
@@ -196,7 +195,6 @@ data:
 
     - label: h2-incoming
       protocol: h2
-      experimental: true
       servers:
       - port: 4241
         ip: 0.0.0.0
@@ -214,7 +212,6 @@ data:
 
     - label: grpc-outgoing
       protocol: h2
-      experimental: true
       servers:
       - port: 4340
         ip: 0.0.0.0
@@ -236,7 +233,6 @@ data:
 
     - label: gprc-incoming
       protocol: h2
-      experimental: true
       servers:
       - port: 4341
         ip: 0.0.0.0
@@ -265,7 +261,6 @@ data:
 
     # HTTP/2 Ingress Controller listening on port 8080
     - protocol: h2
-      experimental: true
       label: h2-ingress
       servers:
         - port: 8080
@@ -296,7 +291,7 @@ spec:
           name: "l5d-config"
       containers:
       - name: l5d
-        image: buoyantio/linkerd:1.3.5
+        image: buoyantio/linkerd:1.3.6
         env:
         - name: POD_IP
           valueFrom:

--- a/linkerd-tcp/docker-compose.yml
+++ b/linkerd-tcp/docker-compose.yml
@@ -62,7 +62,7 @@ services:
     - "-redis-addr=linkerd-tcp:7474"
 
   linkerd:
-    image: buoyantio/linkerd:1.3.5
+    image: buoyantio/linkerd:1.3.6
     ports:
     - 4140:4140 # expose for testing only
     - 9990:9990
@@ -72,7 +72,7 @@ services:
     - "/io.buoyant/linkerd/config.yml"
 
   namerd:
-    image: buoyantio/namerd:1.3.5
+    image: buoyantio/namerd:1.3.6
     ports:
     - 4180:4180
     - 9991:9991
@@ -108,7 +108,7 @@ services:
     - "-redis.addr=redis://redis2:6379"
 
   linkerd-viz:
-    image: buoyantio/linkerd-viz:0.1.7
+    image: buoyantio/linkerd-viz:0.1.8
     environment:
     - SCRAPE_INTERVAL=5s
     ports:

--- a/mesos-marathon/linkerd-marathon.json
+++ b/mesos-marathon/linkerd-marathon.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd:1.3.5",
+      "image": "buoyantio/linkerd:1.3.6",
       "network": "HOST",
       "privileged": true
     }
@@ -36,5 +36,5 @@
     }
   ],
   "requirePorts": true,
-  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"localhost\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.3.5/bundle-exec -log.level=DEBUG -- -"
+  "cmd": "echo \"{\\\"admin\\\":{\\\"ip\\\":\\\"0.0.0.0\\\",\\\"port\\\":9990},\\\"telemetry\\\":[{\\\"kind\\\":\\\"io.l5d.prometheus\\\"}],\\\"namers\\\":[{\\\"kind\\\":\\\"io.l5d.marathon\\\",\\\"host\\\":\\\"localhost\\\",\\\"port\\\":8080}],\\\"routers\\\":[{\\\"protocol\\\":\\\"http\\\",\\\"servers\\\":[{\\\"port\\\":4140,\\\"ip\\\":\\\"0.0.0.0\\\"}],\\\"dtab\\\":\\\"/marathonId=>/#/io.l5d.marathon;/svc=>/$/io.buoyant.http.domainToPathPfx/marathonId;\\\",\\\"label\\\":\\\"linkerd_proxy\\\"}]}\" | /io.buoyant/linkerd/1.3.6/bundle-exec -log.level=DEBUG -- -"
 }

--- a/mesos-marathon/linkerd-viz.json
+++ b/mesos-marathon/linkerd-viz.json
@@ -8,7 +8,7 @@
   "container": {
     "type": "DOCKER",
     "docker": {
-      "image": "buoyantio/linkerd-viz:0.1.7",
+      "image": "buoyantio/linkerd-viz:0.1.8",
       "network": "HOST",
       "privileged": true
     }

--- a/plugins/build.sbt
+++ b/plugins/build.sbt
@@ -6,7 +6,7 @@ def finagle(mod: String) =
   "com.twitter" %% s"finagle-$mod" % "6.45.0"
 
 def linkerd(mod: String) =
-  "io.buoyant" %% s"linkerd-$mod" % "1.3.5"
+  "io.buoyant" %% s"linkerd-$mod" % "1.3.6"
 
 val headerClassifier =
   project.in(file("header-classifier")).


### PR DESCRIPTION
Update examples to Linkerd 1.3.6, linkerd-viz 0.1.8, and remove
experimental flags that are no longer necessary.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>