### PR TITLE
Add documentation on alternative way of installing linkerd on dc/os

### DIFF
--- a/dcos/README.md
+++ b/dcos/README.md
@@ -14,11 +14,13 @@ dcos marathon app add webapp.json
 Note the `linkerd-dcos.json` files assume 4 nodes. Modify this to equal the
 total number of public+private nodes in your cluster.
 
-Note that the `linkerd-dcos.json` is one of many ways you can setup
-Linkerd to run in DC\OS. Unfortunately using `linkerd-dcos.json` might make it
-difficult to send operating system signals to Linkerd e.g. `SIGTERM` for
-graceful shutdown. An [alternative](/linkerd-dcos-with-fetch.json) is one way to
-can set up the Linkerd so that it can catch os signals.
+Note that the [simple-proxy/linkerd-dcos.json](simple-proxy/linkerd-dcos.json)
+is one of many ways you can setup Linkerd to run in DC/OS. Unfortunately using
+`linkerd-dcos.json` might make it difficult to send operating system signals to
+Linkerd e.g. `SIGTERM` for graceful shutdown. An
+[alternative](simple-proxy/linkerd-dcos-with-fetch.json)is one way to set up Linkerd so
+that it can catch os signals. This application definition uses the `fetch`
+API available in DC/OS 1.10. You can use a top-level `uri` list for DC/OS <= 1.9
 
 Multiple linkerd configurations are described below. Pick the one that's most
 appropriate for your setup. When testing configurations, be sure to set the

--- a/dcos/README.md
+++ b/dcos/README.md
@@ -18,9 +18,10 @@ Note that the [simple-proxy/linkerd-dcos.json](simple-proxy/linkerd-dcos.json)
 is one of many ways you can setup Linkerd to run in DC/OS. Unfortunately using
 `linkerd-dcos.json` might make it difficult to send operating system signals to
 Linkerd e.g. `SIGTERM` for graceful shutdown. An
-[alternative](simple-proxy/linkerd-dcos-with-fetch.json)is one way to set up Linkerd so
-that it can catch os signals. This application definition uses the `fetch`
-API available in DC/OS 1.10. You can use a top-level `uri` list for DC/OS <= 1.9
+[alternative](simple-proxy/linkerd-dcos-with-fetch.json) is one way to set up
+Linkerd so that it can catch os signals. This application definition uses the
+`fetch` API available in DC/OS 1.10. You can use a top-level `uri`
+ list for DC/OS <= 1.9.
 
 Multiple linkerd configurations are described below. Pick the one that's most
 appropriate for your setup. When testing configurations, be sure to set the

--- a/dcos/README.md
+++ b/dcos/README.md
@@ -14,6 +14,12 @@ dcos marathon app add webapp.json
 Note the `linkerd-dcos.json` files assume 4 nodes. Modify this to equal the
 total number of public+private nodes in your cluster.
 
+Note that the `linkerd-dcos.json` is one of many ways you can setup
+Linkerd to run in DC\OS. Unfortunately using `linkerd-dcos.json` might make it
+difficult to send operating system signals to Linkerd e.g. `SIGTERM` for
+graceful shutdown. An [alternative](/linkerd-dcos-with-fetch.json) is one way to
+can set up the Linkerd so that it can catch os signals.
+
 Multiple linkerd configurations are described below. Pick the one that's most
 appropriate for your setup. When testing configurations, be sure to set the
 `PUBLIC_NODE` env variable to the external address of the public node in your

--- a/dcos/linkerd-dcos-with-fetch.json
+++ b/dcos/linkerd-dcos-with-fetch.json
@@ -23,7 +23,7 @@
       }
     ],
     "docker": {
-      "image": "buoyantio/linkerd:1.3.6",
+      "image": "buoyantio/linkerd:1.4.0",
       "network": "HOST",
       "privileged": true
     }

--- a/dcos/linkerd-dcos-with-fetch.json
+++ b/dcos/linkerd-dcos-with-fetch.json
@@ -1,0 +1,34 @@
+{
+  "id": "linkerd",
+  "instances": 4,
+  "cpus": 0.25,
+  "mem": 256.0,
+  "acceptedResourceRoles": ["*", "slave_public"],
+  "constraints": [["hostname", "UNIQUE"]],
+  "fetch": [
+    {
+      "uri": "https://<URL TO PRIVATE LINKERD YAML>",
+      "extract": false,
+      "executable": false,
+      "cache": false
+    }
+  ],
+  "container": {
+    "type": "DOCKER",
+    "volumes": [
+      {
+        "containerPath": "/io.buoyant/linkerd/1.3.6/config.yml",
+        "hostPath": "./config.yml",
+        "mode": "RW"
+      }
+    ],
+    "docker": {
+      "image": "buoyantio/linkerd:1.3.6",
+      "network": "HOST",
+      "privileged": true
+    }
+  },
+  "args": [
+    "./config.yml"
+  ]
+}

--- a/dcos/simple-proxy/linkerd-dcos-with-fetch.json
+++ b/dcos/simple-proxy/linkerd-dcos-with-fetch.json
@@ -7,7 +7,7 @@
   "constraints": [["hostname", "UNIQUE"]],
   "fetch": [
     {
-      "uri": "https://<URL TO PRIVATE LINKERD YAML>",
+      "uri": "https://<URL TO PRIVATELY HOSTED LINKERD YAML>/config.yaml",
       "extract": false,
       "executable": false,
       "cache": false
@@ -17,8 +17,8 @@
     "type": "DOCKER",
     "volumes": [
       {
-        "containerPath": "/io.buoyant/linkerd/1.3.6/config.yml",
-        "hostPath": "./config.yml",
+        "containerPath": "/io.buoyant/linkerd/1.4.0/config.yaml",
+        "hostPath": "./config.yaml",
         "mode": "RW"
       }
     ],
@@ -29,6 +29,6 @@
     }
   },
   "args": [
-    "./config.yml"
+    "./config.yaml"
   ]
 }


### PR DESCRIPTION
The current `linkerd-dcos.json` install file used in linkerd examples can prevent the admin shutdown API feature in Linkerd from working. This documentation adds a note that describes a new way to set up a DC\OS linkerd configuration so admin shutdown API feature works in a DC\OS environment.

Signed-off-by: Dennis Adjei-Baah <dennis@buoyant.io>