### PR TITLE
Do not expose Jenkins on an external LoadBalancer

### DIFF
--- a/k8s-daemonset/k8s/jenkins.yml
+++ b/k8s-daemonset/k8s/jenkins.yml
@@ -27,7 +27,6 @@ metadata:
 spec:
   selector:
     app: jenkins
-  type: LoadBalancer
   ports:
   - name: http
     port: 80


### PR DESCRIPTION
The Jenkins example uses Jenkins 2.60.1, which has known
vulnerabilities.

Modify the example to not expose Jenkins to the internet by removing the
LoadBalancer directive from the Jenkins Service definition.

Signed-off-by: Andrew Seigner <siggy@buoyant.io>