### PR TITLE
Introduce Linkerd1 perf test

### DIFF
--- a/perf-baseline/README.md
+++ b/perf-baseline/README.md
@@ -2,10 +2,12 @@
 
 Demonstrates baseline performance metrics for the Linkerd2 Proxy.
 
+A performance test for Linkerd1 may be found at [`linkerd1-perf/`](linkerd1-perf/).
+
 ## Test setup
 
 - 1 pod with 3 containers: load generator -> linkerd2 -> backend
-- 1000qps spread across 10 connections
+- 1000 RPS spread across 10 connections
 - HTTP/1.1 load via [slow_cooker](https://github.com/BuoyantIO/slow_cooker)
 - HTTP/2 load via [strest-grpc](https://github.com/BuoyantIO/strest-grpc)
 - Observability via Prometheus and Grafana

--- a/perf-baseline/linkerd1-perf/README.md
+++ b/perf-baseline/linkerd1-perf/README.md
@@ -1,0 +1,92 @@
+# Linkerd1 performance testing
+
+Test Linkerd1 performance against a released version. For demonstration
+purposes, this example hard-codes an OpenJ9 variant of Linkerd1.
+
+## Test setup
+
+- 1 pod with 3 containers: load generator -> linkerd1 -> backend
+- 1000 RPS spread across 10 connections
+- HTTP/1.1 load via [slow_cooker](https://github.com/BuoyantIO/slow_cooker)
+- HTTP/2 load via [strest-grpc](https://github.com/BuoyantIO/strest-grpc)
+- Observability via Prometheus and Grafana
+- Baseline (no proxy) config for comparison
+
+## Deploy
+
+```bash
+cat linkerd1-perf.yaml | kubectl apply -f -
+```
+
+## Observe
+
+### Grafana
+
+```bash
+kubectl -n linkerd1-perf port-forward $(kubectl -n linkerd1-perf get po --selector=app=grafana -o jsonpath='{.items[*].metadata.name}') 3000:3000
+open http://localhost:3000
+```
+
+<img width="1164" alt="linkerd1-perf" src="https://user-images.githubusercontent.com/236915/43617284-ff3b1ee2-9675-11e8-8877-7d3bd5127045.png">
+
+## Hardware requirements
+
+This test suite boots:
+- 4 Linkerd's
+- 6 load testers at 1000 RPS
+- 6 backend servers
+
+Reommended hardware:
+- 16 cores
+- 8GB memory
+
+## Tuning
+
+Depending on hardware, set `FINAGLE_WORKERS` to twice the number of physical
+cores. Also setting `JVM_HEAP_MIN` and `JVM_HEAP_MAX` to a high value (and the
+same value), can help with memory fragmentation and GC pressure. For example:
+
+```yaml
+image: buoyantio/linkerd:1.4.5
+env:
+- name: FINAGLE_WORKERS
+  value: "32"
+- name: JVM_HEAP_MIN
+  value: 1024M
+- name: JVM_HEAP_MAX
+  value: 1024M
+```
+
+More details on Linkerd performance tuning may be found at:
+https://discourse.linkerd.io/t/linkerd-performance-tuning/447
+
+### Node affinity
+
+To achieve consistent results, consider pinning these processes to known
+hardware nodes, and also setting a taint on those nodes to prevent other
+processes from getting scheduled onto them.
+
+To set a taint:
+
+```bash
+kubectl taint nodes node2 dedicated=groupName:NoSchedule
+```
+
+Then in a PodSpec, specify tolerations for that taint, along with node affinity:
+
+```yaml
+tolerations:
+- key: "dedicated"
+  operator: "Equal"
+  value: "groupName"
+  effect: "NoSchedule"
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - node2
+```

--- a/perf-baseline/linkerd1-perf/linkerd1-perf.yaml
+++ b/perf-baseline/linkerd1-perf/linkerd1-perf.yaml
@@ -1,0 +1,633 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: linkerd1-perf
+---
+#
+# baseline-h1
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baseline-h1
+  namespace: linkerd1-perf
+spec:
+  selector:
+    matchLabels:
+      app: baseline-h1
+  template:
+    metadata:
+      labels:
+        app: baseline-h1
+    spec:
+      containers:
+      - name: slow-cooker
+        image: buoyantio/slow_cooker:1.1.1
+        args:
+        - "-metric-addr=0.0.0.0:9998"
+        - "-qps=100"
+        - "-concurrency=10"
+        - "-interval=10s"
+        - "http://localhost:8080"
+        ports:
+        - name: slow-cooker
+          containerPort: 9998
+      - name: helloworld
+        image: buoyantio/helloworld:0.1.6
+        args:
+        - -addr=:8080
+        - -text=Hello
+        ports:
+        - name: http
+          containerPort: 8080
+---
+#
+# baseline-h2
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: baseline-h2
+  namespace: linkerd1-perf
+spec:
+  selector:
+    matchLabels:
+      app: baseline-h2
+  template:
+    metadata:
+      labels:
+        app: baseline-h2
+    spec:
+      containers:
+      - name: strest-server
+        image: buoyantio/strest-grpc:0.0.6
+        args:
+        - server
+        - --address=0.0.0.0:8080
+        - --metricAddr=0.0.0.0:9998
+        ports:
+        - name: grpc
+          containerPort: 8080
+        - name: strest-server
+          containerPort: 9998
+      - name: strest-client
+        image: buoyantio/strest-grpc:0.0.6
+        args:
+        - client
+        - --totalTargetRps=1000
+        - --address=localhost:8080
+        - --connections=10
+        - --streams=1
+        - --interval=10s
+        - --metricAddr=0.0.0.0:9999
+        ports:
+        - name: strest-client
+          containerPort: 9999
+---
+#
+# linkerd-h1-config
+#
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: linkerd-h1-config
+  namespace: linkerd1-perf
+data:
+  linkerd.yml: |-
+    admin:
+      ip: 0.0.0.0
+      port: 4191
+    routers:
+    - protocol: http
+      experimental: true # for older linkerds
+      dtab: /svc => /$/inet/127.1/8080
+      servers:
+      - ip: 0.0.0.0
+        port: 4143
+    telemetry:
+    - kind: io.l5d.prometheus
+---
+#
+# linkerd-h1 release
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+ name: linkerd-h1-release
+ namespace: linkerd1-perf
+ labels:
+   proxy: challenge
+spec:
+  selector:
+    matchLabels:
+      app:  linkerd-h1-release
+  template:
+    metadata:
+      labels:
+        app:  linkerd-h1-release
+    spec:
+      volumes:
+      - configMap:
+          name: linkerd-h1-config
+        name: linkerd-h1-config
+      containers:
+      - image: buoyantio/linkerd:1.4.5
+        name:  linkerd-h1-release
+        args:
+        - /linkerd-h1-config/linkerd.yml
+        ports:
+        - containerPort: 4143
+          name: linkerd
+        - containerPort: 4191
+          name: linkerd-metrics
+        volumeMounts:
+        - mountPath: /linkerd-h1-config
+          name: linkerd-h1-config
+          readOnly: true
+      - name: slow-cooker
+        image: buoyantio/slow_cooker:1.1.1
+        args:
+        - "-metric-addr=0.0.0.0:9998"
+        - "-qps=100"
+        - "-concurrency=10"
+        - "-interval=10s"
+        - "http://localhost:4143"
+        ports:
+        - name: slow-cooker
+          containerPort: 9998
+      - name: helloworld
+        image: buoyantio/helloworld:0.1.6
+        args:
+        - -addr=:8080
+        - -text=Hello
+        ports:
+        - name: http
+          containerPort: 8080
+---
+#
+# linkerd-h1 openj9
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+ name: linkerd-h1-openj9
+ namespace: linkerd1-perf
+ labels:
+   proxy: challenge
+spec:
+  selector:
+    matchLabels:
+      app:  linkerd-h1-openj9
+  template:
+    metadata:
+      labels:
+        app:  linkerd-h1-openj9
+    spec:
+      volumes:
+      - configMap:
+          name: linkerd-h1-config
+        name: linkerd-h1-config
+      containers:
+      - image: buoyantio/linkerd:1.4.5-openj9-experimental
+        name:  linkerd-h1-openj9
+        args:
+        - /linkerd-h1-config/linkerd.yml
+        ports:
+        - containerPort: 4143
+          name: linkerd
+        - containerPort: 4191
+          name: linkerd-metrics
+        volumeMounts:
+        - mountPath: /linkerd-h1-config
+          name: linkerd-h1-config
+          readOnly: true
+      - name: slow-cooker
+        image: buoyantio/slow_cooker:1.1.1
+        args:
+        - "-metric-addr=0.0.0.0:9998"
+        - "-qps=100"
+        - "-concurrency=10"
+        - "-interval=10s"
+        - "http://localhost:4143"
+        ports:
+        - name: slow-cooker
+          containerPort: 9998
+      - name: helloworld
+        image: buoyantio/helloworld:0.1.6
+        args:
+        - -addr=:8080
+        - -text=Hello
+        ports:
+        - name: http
+          containerPort: 8080
+---
+#
+# linkerd-h2-config
+#
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: linkerd-h2-config
+  namespace: linkerd1-perf
+data:
+  linkerd.yml: |-
+    admin:
+      ip: 0.0.0.0
+      port: 4191
+    routers:
+    - protocol: h2
+      experimental: true # for older linkerds
+      dtab: /svc => /$/inet/127.1/8080
+      servers:
+      - ip: 0.0.0.0
+        port: 4143
+    telemetry:
+    - kind: io.l5d.prometheus
+---
+#
+# linkerd-h2 release
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+ name: linkerd-h2-release
+ namespace: linkerd1-perf
+ labels:
+   proxy: challenge
+spec:
+  selector:
+    matchLabels:
+      app:  linkerd-h2-release
+  template:
+    metadata:
+      labels:
+        app:  linkerd-h2-release
+    spec:
+      volumes:
+      - configMap:
+          name: linkerd-h2-config
+        name: linkerd-h2-config
+      containers:
+      - image: buoyantio/linkerd:1.4.5
+        name:  linkerd-h2-release
+        args:
+        - /linkerd-h2-config/linkerd.yml
+        ports:
+        - containerPort: 4143
+          name: linkerd
+        - containerPort: 4191
+          name: linkerd-metrics
+        volumeMounts:
+        - mountPath: /linkerd-h2-config
+          name: linkerd-h2-config
+          readOnly: true
+      - name: strest-server
+        image: buoyantio/strest-grpc:0.0.6
+        args:
+        - server
+        - --address=0.0.0.0:8080
+        - --metricAddr=0.0.0.0:9998
+        ports:
+        - name: grpc
+          containerPort: 8080
+        - name: strest-server
+          containerPort: 9998
+      - name: strest-client
+        image: buoyantio/strest-grpc:0.0.6
+        args:
+        - client
+        - --totalTargetRps=1000
+        - --address=localhost:4143
+        - --connections=10
+        - --streams=1
+        - --interval=10s
+        - --metricAddr=0.0.0.0:9999
+        ports:
+        - name: strest-client
+          containerPort: 9999
+---
+#
+# linkerd-h2 openj9
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+ name: linkerd-h2-openj9
+ namespace: linkerd1-perf
+ labels:
+   proxy: challenge
+spec:
+  selector:
+    matchLabels:
+      app:  linkerd-h2-openj9
+  template:
+    metadata:
+      labels:
+        app:  linkerd-h2-openj9
+    spec:
+      volumes:
+      - configMap:
+          name: linkerd-h2-config
+        name: linkerd-h2-config
+      containers:
+      - image: buoyantio/linkerd:1.4.5-openj9-experimental
+        name:  linkerd-h2-openj9
+        args:
+        - /linkerd-h2-config/linkerd.yml
+        ports:
+        - containerPort: 4143
+          name: linkerd
+        - containerPort: 4191
+          name: linkerd-metrics
+        volumeMounts:
+        - mountPath: /linkerd-h2-config
+          name: linkerd-h2-config
+          readOnly: true
+      - name: strest-server
+        image: buoyantio/strest-grpc:0.0.6
+        args:
+        - server
+        - --address=0.0.0.0:8080
+        - --metricAddr=0.0.0.0:9998
+        ports:
+        - name: grpc
+          containerPort: 8080
+        - name: strest-server
+          containerPort: 9998
+      - name: strest-client
+        image: buoyantio/strest-grpc:0.0.6
+        args:
+        - client
+        - --totalTargetRps=1000
+        - --address=localhost:4143
+        - --connections=10
+        - --streams=1
+        - --interval=10s
+        - --metricAddr=0.0.0.0:9999
+        ports:
+        - name: strest-client
+          containerPort: 9999
+---
+#
+# Prometheus
+#
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: prometheus
+  namespace: linkerd1-perf
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: linkerd1-perf-prometheus
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "nodes/proxy", "pods"]
+  verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: linkerd1-perf-prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: linkerd1-perf-prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: linkerd1-perf
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: prometheus
+  namespace: linkerd1-perf
+  labels:
+    app: prometheus
+spec:
+  type: ClusterIP
+  selector:
+    app: prometheus
+  ports:
+  - name: admin-http
+    port: 9090
+    targetPort: 9090
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: prometheus-config
+  namespace: linkerd1-perf
+  labels:
+    app: prometheus
+data:
+  prometheus.yml: |-
+    global:
+      scrape_interval: 15s
+      scrape_timeout: 15s
+      evaluation_interval: 15s
+
+    scrape_configs:
+    - job_name: 'prometheus'
+      static_configs:
+      - targets: ['localhost:9090']
+
+    # from https://grafana.com/dashboards/315
+    - job_name: kubernetes-nodes-cadvisor
+      scheme: https  # remove if you want to scrape metrics on insecure port
+      tls_config:
+        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      kubernetes_sd_configs:
+      - role: node
+      relabel_configs:
+      - action: labelmap
+        regex: __meta_kubernetes_node_label_(.+)
+      # Only for Kubernetes ^1.7.3.
+      # See: https://github.com/prometheus/prometheus/issues/2916
+      - target_label: __address__
+        replacement: kubernetes.default.svc:443
+      - source_labels: [__meta_kubernetes_node_name]
+        regex: (.+)
+        target_label: __metrics_path__
+        replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+      metric_relabel_configs:
+      - action: replace
+        source_labels: [id]
+        regex: '^/machine\.slice/machine-rkt\\x2d([^\\]+)\\.+/([^/]+)\.service$'
+        target_label: rkt_container_name
+        replacement: '${2}-${1}'
+      - action: replace
+        source_labels: [id]
+        regex: '^/system\.slice/(.+)\.service$'
+        target_label: systemd_service_name
+        replacement: '${1}'
+      - source_labels:
+        - namespace
+        action: keep
+        regex: ^linkerd1-perf$
+    - job_name: 'strest-server'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: ^linkerd1-perf;strest-server$
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+
+    - job_name: 'strest-client'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: ^linkerd1-perf;strest-client$
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+
+    - job_name: 'slow-cooker'
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels:
+        - __meta_kubernetes_namespace
+        - __meta_kubernetes_pod_container_port_name
+        action: keep
+        regex: ^linkerd1-perf;slow-cooker$
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus
+  namespace: linkerd1-perf
+  labels:
+    app: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      serviceAccount: prometheus
+      volumes:
+      - configMap:
+          name: prometheus-config
+        name: prometheus-config
+      containers:
+      - image: prom/prometheus:v2.3.1
+        name: prometheus
+        args:
+        - --storage.tsdb.retention=6h
+        - --config.file=/etc/prometheus/prometheus.yml
+        ports:
+        - containerPort: 9090
+          name: admin-http
+        volumeMounts:
+        - mountPath: /etc/prometheus
+          name: prometheus-config
+          readOnly: true
+#
+# Grafana
+#
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: grafana-config
+  namespace: linkerd1-perf
+  labels:
+    app: grafana
+data:
+  grafana.ini: |-
+    instance_name = linkerd1-perf-grafana
+
+    [auth]
+    disable_login_form = true
+
+    [auth.anonymous]
+    enabled = true
+    org_role = Editor
+
+    [auth.basic]
+    enabled = false
+
+    [analytics]
+    check_for_updates = false
+
+  datasources.yaml: |-
+    apiVersion: 1
+    datasources:
+    - name: prometheus
+      type: prometheus
+      access: proxy
+      orgId: 1
+      url: http://prometheus.linkerd1-perf.svc.cluster.local:9090
+      isDefault: true
+      jsonData:
+        timeInterval: "5s"
+      version: 1
+      editable: true
+
+  dashboards.yaml: |-
+    apiVersion: 1
+    providers:
+    - name: 'default'
+      orgId: 1
+      folder: ''
+      type: file
+      disableDeletion: true
+      editable: true
+      options:
+        path: /var/lib/grafana/dashboards
+        homeDashboardId: grafana-proxy-challenge
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  namespace: linkerd1-perf
+  labels:
+    app: grafana
+spec:
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - image: gcr.io/linkerd-io/grafana:proxy-challenge
+        imagePullPolicy: Always
+        name: grafana
+        ports:
+        - containerPort: 3000
+          name: http
+        volumeMounts:
+        - mountPath: /etc/grafana
+          name: grafana-config
+          readOnly: true
+      volumes:
+      - configMap:
+          items:
+          - key: grafana.ini
+            path: grafana.ini
+          - key: datasources.yaml
+            path: provisioning/datasources/datasources.yaml
+          - key: dashboards.yaml
+            path: provisioning/dashboards/dashboards.yaml
+          name: grafana-config
+        name: grafana-config


### PR DESCRIPTION
This test environment compares a Linkerd release version against another
variant of Linkerd. In this example, against an OpenJ9 variant. It also
compares performance against a baseline client/server with no proxy.

<img width="1164" alt="linkerd1-perf" src="https://user-images.githubusercontent.com/236915/43617284-ff3b1ee2-9675-11e8-8877-7d3bd5127045.png">

Signed-off-by: Andrew Seigner <siggy@buoyant.io>