### PR TITLE
Lifecycle script improvements

### DIFF
--- a/lifecycle/bin/deploy
+++ b/lifecycle/bin/deploy
@@ -2,7 +2,50 @@
 
 set -e
 
-NAMESPACES=${1:-1}
+usage() {
+  cat <<EOM
+Usage: $0 [NAMESPACES] [options]
+
+Arguments:
+  NAMESPACES                  The number of namespaces to deploy. [default 1]
+
+Options:
+  -n, --ns-prefix <PREFIX>    The prefix of the created lifecycle namespaces. [default 'lifecycle']
+  -l, --ctrl-prefix <PREFIX>  The prefix of the control plane namespaces to use (must already exist). [default 'linkerd-lifecycle']
+      -- <INJECT_ARG>...      Any arguments following a "--" will be passed to the 'linkerd inject' command.
+  -h, --help                  Show this message.
+EOM
+}
+
+NAMESPACES=1
+INJECT_ARGS=""
+NS_PREFIX="lifecycle"
+CTRL_NS_PREFIX="linkerd-lifecycle"
+
+while [ "$1" != "" ]; do
+  case $1 in
+    -h | --help)        usage
+                        exit 0
+                        ;;
+    -n | --ns-prefix)   shift
+                        NS_PREFIX="${1:-$NS_PREFIX}"
+                        ;;
+    -l | --ctrl-prefix) shift
+                        CTRL_NS_PREFIX="${1:-$CTRL_NS_PREFIX}"
+                        ;;
+    --)                 shift
+                        INJECT_ARGS="$*"
+                        break
+                        ;;
+    *[!0-9]*)           echo "Error: Unknown argument '$1'" >&2
+                        usage
+                        exit 1
+                        ;;
+    *)                  NAMESPACES="$1"
+                        ;;
+  esac
+  shift
+done
 
 if [ "$NAMESPACES" -gt 100 ]; then
   echo "Don't deploy more than 100 namespaces"
@@ -11,26 +54,26 @@ fi
 
 echo "Deploying $NAMESPACES injected, TLS, and baseline namespaces..."
 
-for i in `seq 1 $NAMESPACES`;
+for i in $(seq 1 "$NAMESPACES");
 do
-  NS=lifecycle$i
-  NS_TLS=$NS-tls
-  NS_BASELINE=$NS-baseline
+  NS="$NS_PREFIX""$i"
+  NS_TLS="$NS"-tls
+  NS_BASELINE="$NS"-baseline
 
   echo "\nDeploying $NS..."
-  kubectl create ns $NS
+  kubectl create ns "$NS"
   cat lifecycle.yml |
-    linkerd inject --linkerd-namespace linkerd-lifecycle - |
-    kubectl -n $NS apply -f -
+    linkerd inject --linkerd-namespace "$CTRL_NS_PREFIX" $INJECT_ARGS - |
+    kubectl -n "$NS" apply -f -
 
   echo "\nDeploying $NS_TLS..."
-  kubectl create ns $NS_TLS
+  kubectl create ns "$NS_TLS"
   cat lifecycle.yml |
-    linkerd inject --linkerd-namespace linkerd-lifecycle-tls --tls optional - |
-    kubectl -n $NS_TLS apply -f -
+    linkerd inject --linkerd-namespace "$CTRL_NS_PREFIX"-tls $INJECT_ARGS - |
+    kubectl -n "$NS_TLS" apply -f -
 
   echo "\nDeploying $NS_BASELINE..."
-  kubectl create ns $NS_BASELINE
+  kubectl create ns "$NS_BASELINE"
   cat lifecycle.yml |
-    kubectl -n $NS_BASELINE apply -f -
+    kubectl -n "$NS_BASELINE" apply -f -
 done

--- a/lifecycle/bin/deploy
+++ b/lifecycle/bin/deploy
@@ -69,7 +69,7 @@ do
   echo "\nDeploying $NS_TLS..."
   kubectl create ns "$NS_TLS"
   cat lifecycle.yml |
-    linkerd inject --linkerd-namespace "$CTRL_NS_PREFIX"-tls $INJECT_ARGS - |
+    linkerd inject --linkerd-namespace "$CTRL_NS_PREFIX"-tls --tls optional $INJECT_ARGS - |
     kubectl -n "$NS_TLS" apply -f -
 
   echo "\nDeploying $NS_BASELINE..."

--- a/lifecycle/bin/scale
+++ b/lifecycle/bin/scale
@@ -2,12 +2,60 @@
 
 set -e
 
-NAMESPACES=${1:-1}
-REPLICAS=${2:-1}
+usage() {
+  cat <<EOM
+Usage: $0 [NAMESPACES] [REPLICAS] [options]
 
-function scale() {
+Arguments:
+  NAMESPACES                The number of namespaces to scale. [default 1]
+  REPLICAS                  The desired number of replicas to scale to [default 1]
+
+Options:
+  -n, --ns-prefix <PREFIX>  The prefix of the namespaces to scale. [default 'lifecycle']
+  -h, --help                Show this message.
+EOM
+}
+
+NAMESPACES=1
+REPLICAS=1
+NS_PREFIX="lifecycle"
+NUM_NUMERICS=0
+
+while [ "$1" != "" ]; do
+  case $1 in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -n | --ns-prefix)
+      shift
+      NS_PREFIX="${1:-$NS_PREFIX}"
+      ;;
+    *[!0-9]*)
+      echo "Error: Unknown argument '$1'" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      case "$NUM_NUMERICS" in
+        0) NAMESPACES="$1"
+           ;;
+        1) REPLICAS="$1"
+           ;;
+        *) echo "Error: Too many numeric arguments (expected a maximum of 2)" >&2
+           usage
+           exit 1
+           ;;
+      esac
+      NUM_NUMERICS=$(($NUM_NUMERICS + 1))
+      ;;
+  esac
+  shift
+done
+
+scale() {
   echo "\nScaling $1 to $REPLICAS replicas..."
-  kubectl -n $1 scale --replicas=$REPLICAS deploy/bb-broadcast deploy/bb-p2p deploy/bb-terminus
+  kubectl -n "$1" scale --replicas="$REPLICAS" deploy/bb-broadcast deploy/bb-p2p deploy/bb-terminus
 }
 
 if [ "$NAMESPACES" -gt 100 ]; then
@@ -22,9 +70,9 @@ fi
 
 echo "Scaling $NAMESPACES injected, TLS, and baseline namespaces to $REPLICAS replicas..."
 
-for i in `seq 1 $NAMESPACES`;
+for i in $(seq 1 "$NAMESPACES");
 do
-  NS=lifecycle$i
+  NS="$NS_PREFIX""$i"
 
   scale "$NS"
   scale "$NS-tls"

--- a/lifecycle/bin/teardown
+++ b/lifecycle/bin/teardown
@@ -2,17 +2,49 @@
 
 set -e
 
-NAMESPACES=${1:-1}
+usage() {
+  cat <<EOM
+Usage: $0 [NAMESPACES] [options]
+
+Arguments:
+  NAMESPACES                A positive integer that sets the number of namespaces to tear down. [default 1]
+
+Options:
+  -n, --ns-prefix <PREFIX>  Set the prefix of the lifecycle namespaces to tear down. [default 'lifecycle']
+  -h, --help                Show this message.
+EOM
+}
+
+NAMESPACES=1
+NS_PREFIX="lifecycle"
+
+while [ "$1" != "" ]; do
+  case $1 in
+    -h | --help)        usage
+                        exit 0
+                        ;;
+    -n | --ns-prefix)   shift
+                        NS_PREFIX="${1:-$NS_PREFIX}"
+                        ;;
+    *[!0-9]*)           echo "Error: Unknown argument '$1'" >&2
+                        usage
+                        exit 1
+                        ;;
+    *)                  NAMESPACES="$1"
+                        ;;
+  esac
+  shift
+done
 
 echo "Tearing down $NAMESPACES injected, TLS, and baseline namespaces...\n"
 
-for i in `seq 1 $NAMESPACES`;
+TO_DELETE=""
+for i in $(seq 1 "$NAMESPACES");
 do
-  NS=lifecycle$i
-  NS_TLS=$NS-tls
-  NS_BASELINE=$NS-baseline
+  NS="$NS_PREFIX""$i"
+  NS_TLS="$NS"-tls
+  NS_BASELINE="$NS"-baseline
 
-  kubectl delete ns $NS || true
-  kubectl delete ns $NS_TLS || true
-  kubectl delete ns $NS_BASELINE || true
+  TO_DELETE="$TO_DELETE $NS $NS_TLS $NS_BASELINE"
 done
+kubectl delete ns "$TO_DELETE" || true

--- a/lifecycle/bin/teardown
+++ b/lifecycle/bin/teardown
@@ -47,4 +47,4 @@ do
 
   TO_DELETE="$TO_DELETE $NS $NS_TLS $NS_BASELINE"
 done
-kubectl delete ns "$TO_DELETE" || true
+kubectl delete ns $TO_DELETE || true


### PR DESCRIPTION
This branch makes a number of improvements to the scripts for the 
lifecycle example, primarily based on changes I found useful while
using this example for testing.

In particular:

* `bin/deploy` now takes an optional `--ctrl-prefix` flag to
  configure the prefix added to the name of the Linkerd control
  plane namespace. This is sometimes valuable when running multiple
  lifecycle tests in the same cluster.
* `bin/deploy`, `bin/scale`, and `bin/teardown` all take an optional
  `--ns-prefix` flag that configures the prefix added to the Linkerd
  namespaces created or modified by the script.
* `bin/teardown` now deletes all namespaces with one `kubectl delete`
  command. This is because `kubectl` was recently changed so that the
  delete command will block until the resource is deleted, so running
  multiple `kubectl delete`s in parallel takes much longer than it did
  previously. The script now tries to delete the namespaces in parallel.
* `bin/deploy` now allows arbitrary arguments to be passed to the 
  `linkerd inject` command. This is valuable when testing a version of
  the Linkerd proxy other than the one that `inject` uses by default,
  when a more verbose proxy log level is desired for debugging, and
  so on.
* All scripts now print usage messages when provided with unrecognizable
  arguments.
* Fixed some `shellcheck` lints.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>