### PR TITLE
Slim down backend images used in demos

### DIFF
--- a/failure-accrual/Dockerfile
+++ b/failure-accrual/Dockerfile
@@ -1,3 +1,11 @@
-FROM golang:onbuild
+FROM golang:1.10.3 as builder
+WORKDIR /go/src/github.com/linkerd/linkerd-examples/failure-accrual/
+RUN go get -d -v github.com/prometheus/client_golang/prometheus
+COPY server.go .
+RUN CGO_ENABLED=0 GOOS=linux go build -o app .
 
-ENTRYPOINT ["app"]
+FROM alpine:3.8
+RUN apk --no-cache add curl
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/linkerd/linkerd-examples/failure-accrual/app .
+ENTRYPOINT ["./app"]

--- a/influxdb/Dockerfile
+++ b/influxdb/Dockerfile
@@ -1,3 +1,11 @@
-FROM golang:onbuild
+FROM golang:1.10.3 as builder
+WORKDIR /go/src/github.com/linkerd/linkerd-examples/influxdb/
+RUN go get -d -v github.com/prometheus/client_golang/prometheus
+COPY app.go .
+RUN CGO_ENABLED=0 GOOS=linux go build -o app .
 
-ENTRYPOINT ["app"]
+FROM alpine:3.8
+RUN apk --no-cache add curl
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/linkerd/linkerd-examples/influxdb/app .
+ENTRYPOINT ["./app"]

--- a/linkerd-tcp/Dockerfile
+++ b/linkerd-tcp/Dockerfile
@@ -5,6 +5,7 @@ COPY web.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -o app .
 
 FROM alpine:3.8
+RUN apk --no-cache add curl
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/linkerd/linkerd-examples/linkerd-tcp/app .
 ENTRYPOINT ["./app"]

--- a/linkerd-tcp/Dockerfile
+++ b/linkerd-tcp/Dockerfile
@@ -1,3 +1,10 @@
-FROM golang:1.8-onbuild
+FROM golang:1.10.3 as builder
+WORKDIR /go/src/github.com/linkerd/linkerd-examples/linkerd-tcp/
+RUN go get -d -v github.com/go-redis/redis
+COPY web.go .
+RUN CGO_ENABLED=0 GOOS=linux go build -o app .
 
-ENTRYPOINT ["app"]
+FROM alpine:3.8
+WORKDIR /root/
+COPY --from=builder /go/src/github.com/linkerd/linkerd-examples/linkerd-tcp/app .
+ENTRYPOINT ["./app"]


### PR DESCRIPTION
Dcoker's onbuild images are deprecated. This change switches the linkerd-tcp demo to use a multistage build instead of an onbuild image. If I get a chance I'll make the equivalent change in `influxdb/Dockerfile` and `failure-accrual/Dockerfile`.