### PR TITLE
Bump all kubectl containers to v1.12.2

### DIFF
--- a/add-steps/k8s/add-steps.yml
+++ b/add-steps/k8s/add-steps.yml
@@ -209,7 +209,7 @@ spec:
           mountPath: "/io.buoyant/linkerd/config"
           readOnly: true
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/docker/jenkins-plus/README.md
+++ b/docker/jenkins-plus/README.md
@@ -9,7 +9,7 @@ directory so that it can be included in the image. Pull it out of the latest
 buoyantio/kubectl docker image:
 
 ```bash
-$ docker run --name kubectl -d buoyantio/kubectl:v1.8.5
+$ docker run --name kubectl -d buoyantio/kubectl:v1.12.2
 $ docker cp kubectl:/kubectl .
 $ docker rm -vf kubectl
 ```

--- a/getting-started/k8s/linkerd.yml
+++ b/getting-started/k8s/linkerd.yml
@@ -60,7 +60,7 @@ spec:
         # We run a kubectl proxy container so that linkerd can talk to the
         # Kubernetes master API.
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - proxy
         - "-p"

--- a/gob/k8s/namerd/rc.yml
+++ b/gob/k8s/namerd/rc.yml
@@ -37,7 +37,7 @@ spec:
               mountPath: "/io.buoyant/namerd/config"
               readOnly: true
         - name: kubectl
-          image: buoyantio/kubectl:v1.8.5
+          image: buoyantio/kubectl:v1.12.2
           args:
           - "proxy"
           - "-p"

--- a/istio/helloworld-grpc-minikube/istio-ingress.yml
+++ b/istio/helloworld-grpc-minikube/istio-ingress.yml
@@ -66,7 +66,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args: ["proxy", "-p", "8001"]
 ---
 apiVersion: v1

--- a/istio/istio-daemonset-grpc.yml
+++ b/istio/istio-daemonset-grpc.yml
@@ -99,7 +99,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/istio/istio-daemonset.yml
+++ b/istio/istio-daemonset.yml
@@ -100,7 +100,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/istio/istio-egress.yml
+++ b/istio/istio-egress.yml
@@ -70,7 +70,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/istio/istio-ingress.yml
+++ b/istio/istio-ingress.yml
@@ -74,7 +74,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args: ["proxy", "-p", "8001"]
 ---
 apiVersion: v1

--- a/istio/istio-linkerd.yml
+++ b/istio/istio-linkerd.yml
@@ -221,7 +221,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"
@@ -315,7 +315,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args: ["proxy", "-p", "8001"]
 ---
 apiVersion: v1
@@ -408,7 +408,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/api-legacy.yml
+++ b/k8s-daemonset/k8s/api-legacy.yml
@@ -37,7 +37,7 @@ spec:
         - name: service
           containerPort: 7779
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - proxy
         - "-p"

--- a/k8s-daemonset/k8s/api.yml
+++ b/k8s-daemonset/k8s/api.yml
@@ -36,7 +36,7 @@ spec:
         - name: service
           containerPort: 7779
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - proxy
         - "-p"

--- a/k8s-daemonset/k8s/hello-world-grpc-legacy.yaml
+++ b/k8s-daemonset/k8s/hello-world-grpc-legacy.yaml
@@ -37,7 +37,7 @@ spec:
         - name: service
           containerPort: 7777
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - proxy
         - "-p"

--- a/k8s-daemonset/k8s/hello-world-legacy.yml
+++ b/k8s-daemonset/k8s/hello-world-legacy.yml
@@ -37,7 +37,7 @@ spec:
         - name: service
           containerPort: 7777
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - proxy
         - "-p"

--- a/k8s-daemonset/k8s/linkerd-cni-legacy.yml
+++ b/k8s-daemonset/k8s/linkerd-cni-legacy.yml
@@ -109,7 +109,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/linkerd-cni.yml
+++ b/k8s-daemonset/k8s/linkerd-cni.yml
@@ -110,7 +110,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/linkerd-egress.yaml
+++ b/k8s-daemonset/k8s/linkerd-egress.yaml
@@ -106,7 +106,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/linkerd-grpc.yml
+++ b/k8s-daemonset/k8s/linkerd-grpc.yml
@@ -103,7 +103,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/linkerd-ingress-controller.yml
+++ b/k8s-daemonset/k8s/linkerd-ingress-controller.yml
@@ -62,7 +62,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args: ["proxy", "-p", "8001"]
 ---
 apiVersion: v1

--- a/k8s-daemonset/k8s/linkerd-ingress.yml
+++ b/k8s-daemonset/k8s/linkerd-ingress.yml
@@ -175,7 +175,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/linkerd-latency.yml
+++ b/k8s-daemonset/k8s/linkerd-latency.yml
@@ -102,7 +102,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/linkerd-namerd-cni.yml
+++ b/k8s-daemonset/k8s/linkerd-namerd-cni.yml
@@ -220,7 +220,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/linkerd-namerd.yml
+++ b/k8s-daemonset/k8s/linkerd-namerd.yml
@@ -102,7 +102,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/linkerd-tls-ingress-controller.yml
+++ b/k8s-daemonset/k8s/linkerd-tls-ingress-controller.yml
@@ -72,7 +72,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args: ["proxy", "-p", "8001"]
 ---
 apiVersion: v1

--- a/k8s-daemonset/k8s/linkerd-tls.yml
+++ b/k8s-daemonset/k8s/linkerd-tls.yml
@@ -115,7 +115,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/linkerd-zipkin.yml
+++ b/k8s-daemonset/k8s/linkerd-zipkin.yml
@@ -104,7 +104,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/linkerd.yml
+++ b/k8s-daemonset/k8s/linkerd.yml
@@ -151,7 +151,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/namerd-legacy.yml
+++ b/k8s-daemonset/k8s/namerd-legacy.yml
@@ -76,7 +76,7 @@ spec:
           mountPath: "/io.buoyant/namerd/config"
           readOnly: true
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/namerd.yml
+++ b/k8s-daemonset/k8s/namerd.yml
@@ -81,7 +81,7 @@ spec:
           mountPath: "/io.buoyant/namerd/config"
           readOnly: true
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/k8s-daemonset/k8s/servicemesh.yml
+++ b/k8s-daemonset/k8s/servicemesh.yml
@@ -331,7 +331,7 @@ spec:
       # Run `kubectl proxy` as a sidecar to give us authenticated access to the
       # Kubernetes API.
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"

--- a/lifecycle/linkerd1/linkerd.yml
+++ b/lifecycle/linkerd1/linkerd.yml
@@ -169,7 +169,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"
@@ -330,7 +330,7 @@ spec:
           readOnly: true
 
       - name: kubectl
-        image: buoyantio/kubectl:v1.8.5
+        image: buoyantio/kubectl:v1.12.2
         args:
         - "proxy"
         - "-p"


### PR DESCRIPTION
Follow up from https://github.com/BuoyantIO/kubectl/pull/2

Signed-off-by: Andrew Seigner <siggy@buoyant.io>