### PR TITLE
Bump images in lifecycle environment, remove tls

### DIFF
--- a/lifecycle/README.md
+++ b/lifecycle/README.md
@@ -26,7 +26,6 @@ Deploy 3 lifecycle environments:
 
 ```bash
 linkerd install --linkerd-namespace linkerd-lifecycle | kubectl apply -f -
-linkerd install --linkerd-namespace linkerd-lifecycle-tls --tls optional | kubectl apply -f -
 bin/deploy 3
 ```
 
@@ -37,7 +36,7 @@ Scale 3 lifecycle environments to 3 replicas of `bb-broadcast`, `bb-p2p`, and
 bin/scale 3 3
 ```
 
-Total mesh-enabled pod count == (1 linkerd ns + 1 linkerd tls ns) * (3*replicas+2)
+Total mesh-enabled pod count == 1 linkerd ns * (3*replicas+2)
 
 Teardown 3 lifecycle environments:
 
@@ -45,7 +44,6 @@ Teardown 3 lifecycle environments:
 bin/teardown 3
 
 kubectl delete ns linkerd-lifecycle
-kubectl delete ns linkerd-lifecycle-tls
 ```
 
 ## Individual Deploy / Scale / Teardown

--- a/lifecycle/bin/deploy
+++ b/lifecycle/bin/deploy
@@ -57,7 +57,6 @@ echo "Deploying $NAMESPACES injected, TLS, and baseline namespaces..."
 for i in $(seq 1 "$NAMESPACES");
 do
   NS="$NS_PREFIX""$i"
-  NS_TLS="$NS"-tls
   NS_BASELINE="$NS"-baseline
 
   echo "\nDeploying $NS..."
@@ -65,12 +64,6 @@ do
   cat lifecycle.yml |
     linkerd inject --linkerd-namespace "$CTRL_NS_PREFIX" $INJECT_ARGS - |
     kubectl -n "$NS" apply -f -
-
-  echo "\nDeploying $NS_TLS..."
-  kubectl create ns "$NS_TLS"
-  cat lifecycle.yml |
-    linkerd inject --linkerd-namespace "$CTRL_NS_PREFIX"-tls --tls optional $INJECT_ARGS - |
-    kubectl -n "$NS_TLS" apply -f -
 
   echo "\nDeploying $NS_BASELINE..."
   kubectl create ns "$NS_BASELINE"

--- a/lifecycle/bin/scale
+++ b/lifecycle/bin/scale
@@ -75,6 +75,5 @@ do
   NS="$NS_PREFIX""$i"
 
   scale "$NS"
-  scale "$NS-tls"
   scale "$NS-baseline"
 done

--- a/lifecycle/bin/teardown
+++ b/lifecycle/bin/teardown
@@ -42,9 +42,8 @@ TO_DELETE=""
 for i in $(seq 1 "$NAMESPACES");
 do
   NS="$NS_PREFIX""$i"
-  NS_TLS="$NS"-tls
   NS_BASELINE="$NS"-baseline
 
-  TO_DELETE="$TO_DELETE $NS $NS_TLS $NS_BASELINE"
+  TO_DELETE="$TO_DELETE $NS $NS_BASELINE"
 done
 kubectl delete ns $TO_DELETE || true

--- a/lifecycle/lifecycle.yml
+++ b/lifecycle/lifecycle.yml
@@ -29,7 +29,6 @@ spec:
     spec:
       containers:
       - image: buoyantio/slow_cooker:1.2.0
-        imagePullPolicy: IfNotPresent
         name: slow-cooker
         command:
         - "/bin/sh"
@@ -77,8 +76,7 @@ spec:
         app: bb-p2p
     spec:
       containers:
-      - image: buoyantio/bb:v0.0.3
-        imagePullPolicy: IfNotPresent
+      - image: buoyantio/bb:v0.0.5
         name: bb-p2p
         command:
         - "/bin/bash"
@@ -123,8 +121,7 @@ spec:
         app: bb-broadcast
     spec:
       containers:
-      - image: buoyantio/bb:v0.0.3
-        imagePullPolicy: IfNotPresent
+      - image: buoyantio/bb:v0.0.5
         name: bb-broadcast
         command:
         - "/bin/bash"
@@ -286,8 +283,7 @@ spec:
         app: bb-terminus
     spec:
       containers:
-      - image: buoyantio/bb:v0.0.3
-        imagePullPolicy: IfNotPresent
+      - image: buoyantio/bb:v0.0.5
         name: bb-terminus
         command:
         - "/bin/bash"
@@ -405,8 +401,7 @@ spec:
     spec:
       serviceAccount: redeployer
       containers:
-      - image: lachlanevenson/k8s-kubectl:v1.10.3
-        imagePullPolicy: IfNotPresent
+      - image: lachlanevenson/k8s-kubectl:v1.14.0
         name: redeployer
         command:
         - "/data/redeployer"

--- a/lifecycle/linkerd1/lifecycle.yml
+++ b/lifecycle/linkerd1/lifecycle.yml
@@ -28,7 +28,6 @@ spec:
     spec:
       containers:
       - image: buoyantio/slow_cooker:1.2.0
-        imagePullPolicy: IfNotPresent
         name: slow-cooker
         env:
         - name: HOST_IP
@@ -86,8 +85,7 @@ spec:
         app: bb-p2p
     spec:
       containers:
-      - image: buoyantio/bb:latest
-        imagePullPolicy: Always
+      - image: buoyantio/bb:v0.0.5
         name: bb-p2p
         env:
         - name: HOST_IP
@@ -143,8 +141,7 @@ spec:
         app: bb-broadcast
     spec:
       containers:
-      - image: buoyantio/bb:latest
-        imagePullPolicy: Always
+      - image: buoyantio/bb:v0.0.5
         name: bb-broadcast
         env:
         - name: HOST_IP
@@ -317,8 +314,7 @@ spec:
         app: bb-terminus
     spec:
       containers:
-      - image: buoyantio/bb:latest
-        imagePullPolicy: Always
+      - image: buoyantio/bb:v0.0.5
         name: bb-terminus
         command:
         - "/bin/bash"
@@ -437,8 +433,7 @@ spec:
     spec:
       serviceAccount: redeployer
       containers:
-      - image: lachlanevenson/k8s-kubectl:v1.10.3
-        imagePullPolicy: IfNotPresent
+      - image: lachlanevenson/k8s-kubectl:v1.14.0
         name: redeployer
         command:
         - "/data/redeployer"


### PR DESCRIPTION
Linkerd master now enables TLS by default, remove the TLS-specific
namespace, as it's now redundant.

Also bump the following:
- buoyantio/bb:v0.0.3 -> v0.0.5
- lachlanevenson/k8s-kubectl:v1.10.3 -> v1.14.0

Signed-off-by: Andrew Seigner <siggy@buoyant.io>