### PR TITLE
fix: helm charts url

### DIFF
--- a/gitops/argo-apps/sealed-secrets.yaml
+++ b/gitops/argo-apps/sealed-secrets.yaml
@@ -10,5 +10,5 @@ spec:
   project: demo
   source:
     chart: sealed-secrets
-    repoURL: https://kubernetes-charts.storage.googleapis.com
+    repoURL: https://charts.helm.sh/stable
     targetRevision: 1.10.3

--- a/gitops/project.yaml
+++ b/gitops/project.yaml
@@ -37,4 +37,4 @@ spec:
   - https://charts.jetstack.io
   - https://github.com/BuoyantIO/emojivoto.git
   - https://helm.linkerd.io/stable
-  - https://kubernetes-charts.storage.googleapis.com
+  - https://charts.helm.sh/stable


### PR DESCRIPTION
Based on https://helm.sh/blog/new-location-stable-incubator-charts/
`https://kubernetes-charts.storage.googleapis.com` has been changed to `https://charts.helm.sh/stable`

This will help solve the issue I met at https://github.com/linkerd/linkerd2/issues/6385