### PR TITLE
Update cert-manager to v1.0.4 to match ArgoCD

### DIFF
--- a/gitops/README.md
+++ b/gitops/README.md
@@ -9,7 +9,7 @@ The scripts and commands are tested with the following software:
 1. [kind](https://kind.sigs.k8s.io/) v0.8.1
 1. [Linkerd](https://linkerd.io/) 2.8.1
 1. [Argo CD](https://argoproj.github.io/argo-cd/) v1.6.1
-1. [cert-manager](https://cert-manager.io) 0.15.0
+1. [cert-manager](https://cert-manager.io) 1.0.4
 1. [sealed-secrets](https://github.com/bitnami-labs/sealed-secrets) 0.12.4
 
 ## Highlights

--- a/gitops/argo-apps/cert-manager.yaml
+++ b/gitops/argo-apps/cert-manager.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: cert-manager
     repoURL: https://charts.jetstack.io
-    targetRevision: v0.15.0
+    targetRevision: v1.0.4
     helm:
       parameters:
       - name: installCRDs


### PR DESCRIPTION
As discussed in Issue #265, there is an error when running `argocd app sync linkerd-bootstrap` this PR should resolve this issue by updating cert-manager to match the version used by ArgoCD.