### PR TITLE
Update cert-manager version to use v1.8.2

### DIFF
--- a/gitops/argo-apps/cert-manager.yaml
+++ b/gitops/argo-apps/cert-manager.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: cert-manager
     repoURL: https://charts.jetstack.io
-    targetRevision: v1.0.4
+    targetRevision: v1.8.2
     helm:
       parameters:
       - name: installCRDs


### PR DESCRIPTION
When using v1.0.4, the following error is encountered. 
`cert-manager/ca-injector "msg"="error registering core-only controllers" "error"="no matches for kind \"MutatingWebhookConfiguration\" in version \"admissionregistration.k8s.io/v1beta1\""`

This is resolved when using the updated cert-manager.