### PR TITLE
Update sealed-secrets to use v2.4.0

### DIFF
--- a/gitops/argo-apps/sealed-secrets.yaml
+++ b/gitops/argo-apps/sealed-secrets.yaml
@@ -11,4 +11,4 @@ spec:
   source:
     chart: sealed-secrets
     repoURL: https://bitnami-labs.github.io/sealed-secrets
-    targetRevision: 1.16.1
+    targetRevision: v2.4.0


### PR DESCRIPTION
When using 1.16.1, the following error is encountered. 
`Failed to pull image "quay.io/bitnami/sealed-secrets-controller:v0.16.0": rpc error: code = Unknown desc = failed to pull and unpack image "quay.io/bitnami/sealed-secrets-controller:v0.16.0": failed to resolve reference "quay.io/bitnami/sealed-secrets-controller:v0.16.0": pulling from host quay.io failed with status code [manifests v0.16.0]: 401 UNAUTHORIZED`

This is resolved when using the updated sealed-secrets.