### PR TITLE
Fixing broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ information:
 Provides a self-contained docker-compose environment that can be used to test
 various failure accrual settings. More information:
 
-* [Making microservices more resilient with advanced circuit breaking](https://blog.buoyant.io/2017/01/13/making-microservices-more-resilient-with-circuit-breaking/)
+* [Making microservices more resilient with advanced circuit breaking](https://linkerd.io/2017/01/14/making-microservices-more-resilient-with-circuit-breaking/)
 
 ## Gob's microservice
 

--- a/failure-accrual/README.md
+++ b/failure-accrual/README.md
@@ -5,7 +5,7 @@ can use to test [linkerd's failure accrual settings](
 https://linkerd.io/features/circuit-breaking/#failure-accrual). The results of
 the demo are discussed in much more detail in Buoyant's blog post, [Making
 microservices more resilient with advanced circuit breaking](
-https://blog.buoyant.io/2017/01/13/making-microservices-more-resilient-with-circuit-breaking/).
+https://linkerd.io/2017/01/14/making-microservices-more-resilient-with-circuit-breaking/).
 
 ## Startup
 


### PR DESCRIPTION
Linked page seams to have been moved to a new url.

The new URL I provided linkes back to this repo, so I'm fairly confident that my suggestion is an accurate replacement.