### PR TITLE
Update gitops app versions.

### DIFF
--- a/gitops/README.md
+++ b/gitops/README.md
@@ -6,11 +6,11 @@ This project contains scripts and instructions to manage
 
 The scripts and commands are tested with the following software:
 
-1. [kind](https://kind.sigs.k8s.io/) v0.8.1
-1. [Linkerd](https://linkerd.io/) 2.8.1
-1. [Argo CD](https://argoproj.github.io/argo-cd/) v1.6.1
-1. [cert-manager](https://cert-manager.io) 1.0.4
-1. [sealed-secrets](https://github.com/bitnami-labs/sealed-secrets) 0.12.4
+1. [k3d](https://k3d.io/) v5.4.6
+1. [Linkerd](https://linkerd.io/) 2.12.0
+1. [Argo CD](https://argoproj.github.io/argo-cd/) v2.4.12
+1. [cert-manager](https://cert-manager.io) 1.9.1
+1. [sealed-secrets](https://github.com/bitnami-labs/sealed-secrets) 0.18.5
 
 ## Highlights
 

--- a/gitops/argo-apps/cert-manager.yaml
+++ b/gitops/argo-apps/cert-manager.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: cert-manager
     repoURL: https://charts.jetstack.io
-    targetRevision: v1.0.4
+    targetRevision: v1.9.1
     helm:
       parameters:
       - name: installCRDs

--- a/gitops/argo-apps/linkerd-control-plane.yaml
+++ b/gitops/argo-apps/linkerd-control-plane.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: linkerd-control-plane
     repoURL: https://helm.linkerd.io/stable
-    targetRevision: 2.12.0
+    targetRevision: 1.9.3
     helm:
       parameters:
       - name: identityTrustAnchorsPEM

--- a/gitops/argo-apps/linkerd-control-plane.yaml
+++ b/gitops/argo-apps/linkerd-control-plane.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: linkerd-control-plane
     repoURL: https://helm.linkerd.io/stable
-    targetRevision: 1.9.3
+    targetRevision: 1.9.0
     helm:
       parameters:
       - name: identityTrustAnchorsPEM

--- a/gitops/argo-apps/linkerd-crds.yaml
+++ b/gitops/argo-apps/linkerd-crds.yaml
@@ -8,7 +8,7 @@ spec:
   source:
     chart: linkerd-crds
     repoURL: https://helm.linkerd.io/stable
-    targetRevision: 1.0.0
+    targetRevision: 1.4.0
     helm:
   destination:
     namespace: linkerd

--- a/gitops/argo-apps/sealed-secrets.yaml
+++ b/gitops/argo-apps/sealed-secrets.yaml
@@ -11,4 +11,4 @@ spec:
   source:
     chart: sealed-secrets
     repoURL: https://bitnami-labs.github.io/sealed-secrets
-    targetRevision: 1.16.1
+    targetRevision: 2.6.9


### PR DESCRIPTION
The version of the linkerd-control-plane was off so I updated the versions of all the apps inside the argo app. (Also ups the versions in #269 and #270)

I tested the changes locally and everything seemed to work.

https://linkerd.slack.com/archives/C89RTCWJF/p1664028576347719

Signed-off-by: Dominik Táskai <dominik.taskai@leannet.eu>